### PR TITLE
2019-18-11 GUARD-280 Switching-To-V3-Catalog-API

### DIFF
--- a/src/BigCommerceAccess/BigCommerceBaseProductsService.cs
+++ b/src/BigCommerceAccess/BigCommerceBaseProductsService.cs
@@ -1,4 +1,5 @@
 ﻿using BigCommerceAccess.Misc;
+using BigCommerceAccess.Models.Command;
 using BigCommerceAccess.Models.Configuration;
 using BigCommerceAccess.Models.Product;
 using BigCommerceAccess.Services;
@@ -20,6 +21,72 @@ namespace BigCommerceAccess
 			Condition.Requires( services, "services" ).IsNotNull();
 
 			this._webRequestServices = services;
+		}
+
+		protected virtual void FillWeightUnit( IEnumerable< BigCommerceProduct > products, string marker )
+		{
+			var store = ActionPolicies.Get.Get( () =>
+				this._webRequestServices.GetResponse< BigCommerceStore >( BigCommerceCommand.GetStoreV2_OAuth, string.Empty, marker ) );
+			this.CreateApiDelay( store.Limits ).Wait(); //API requirement
+
+			foreach( var product in products )
+			{
+				product.WeightUnit = store.Response.WeightUnits;
+			}
+		}
+
+		protected virtual async Task FillWeightUnitAsync( IEnumerable< BigCommerceProduct > products, CancellationToken token, string marker )
+		{
+			var store = await ActionPolicies.GetAsync.Get( async () =>
+				await this._webRequestServices.GetResponseAsync< BigCommerceStore >( BigCommerceCommand.GetStoreV2_OAuth, string.Empty, marker ) );
+			await this.CreateApiDelay( store.Limits, token ); //API requirement
+
+			foreach( var product in products )
+			{
+				product.WeightUnit = store.Response.WeightUnits;
+			}
+		}
+
+		protected virtual void FillBrands( IEnumerable< BigCommerceProduct > products, string marker )
+		{
+			var brands = new List< BigCommerceBrand >();
+			for( var i = 1; i < int.MaxValue; i++ )
+			{
+				var endpoint = ParamsBuilder.CreateGetNextPageParams( new BigCommerceCommandConfig( i, RequestMaxLimit ) );
+				var brandsWithinPage = ActionPolicies.Get.Get( () =>
+					this._webRequestServices.GetResponse< List< BigCommerceBrand > >( BigCommerceCommand.GetBrandsV2_OAuth, endpoint, marker ) );
+				this.CreateApiDelay( brandsWithinPage.Limits ).Wait(); //API requirement
+
+				if( brandsWithinPage.Response == null )
+					break;
+
+				brands.AddRange( brandsWithinPage.Response );
+				if( brandsWithinPage.Response.Count < RequestMaxLimit )
+					break;
+			}
+
+			this.FillBrandsForProducts( products, brands );
+		}
+
+		protected virtual async Task FillBrandsAsync( IEnumerable< BigCommerceProduct > products, CancellationToken token, string marker )
+		{
+			var brands = new List< BigCommerceBrand >();
+			for( var i = 1; i < int.MaxValue; i++ )
+			{
+				var endpoint = ParamsBuilder.CreateGetNextPageParams( new BigCommerceCommandConfig( i, RequestMaxLimit ) );
+				var brandsWithinPage = await ActionPolicies.GetAsync.Get( async () =>
+					await this._webRequestServices.GetResponseAsync< List< BigCommerceBrand > >( BigCommerceCommand.GetBrandsV2_OAuth, endpoint, marker ) );
+				await this.CreateApiDelay( brandsWithinPage.Limits, token ); //API requirement
+
+				if( brandsWithinPage.Response == null )
+					break;
+
+				brands.AddRange( brandsWithinPage.Response );
+				if( brandsWithinPage.Response.Count < RequestMaxLimit )
+					break;
+			}
+
+			this.FillBrandsForProducts( products, brands );
 		}
 
 		protected void FillProductsSkus( IEnumerable< BigCommerceProduct > products, string marker )

--- a/src/BigCommerceAccess/BigCommerceFactory.cs
+++ b/src/BigCommerceAccess/BigCommerceFactory.cs
@@ -28,7 +28,7 @@ namespace BigCommerceAccess
 				return new BigCommerceProductsServiceV2( services );
 			}
 
-			return new BigCommerceProductsServiceV3( services, new BigCommerceProductsServiceV2OAuth( services ) );
+			return new BigCommerceProductsServiceV3( services );
 		}
 	}
 }

--- a/src/BigCommerceAccess/BigCommerceProductsServiceV2.cs
+++ b/src/BigCommerceAccess/BigCommerceProductsServiceV2.cs
@@ -78,7 +78,7 @@ namespace BigCommerceAccess
 			return products;
 		}
 
-		private void FillWeightUnit( IEnumerable< BigCommerceProduct > products, string marker )
+		protected override void FillWeightUnit( IEnumerable< BigCommerceProduct > products, string marker )
 		{
 			var store = ActionPolicies.Get.Get( () =>
 				this._webRequestServices.GetResponse< BigCommerceStore >( BigCommerceCommand.GetStoreV2, string.Empty, marker ) );
@@ -90,7 +90,7 @@ namespace BigCommerceAccess
 			}
 		}
 
-		private async Task FillWeightUnitAsync( IEnumerable< BigCommerceProduct > products, CancellationToken token, string marker )
+		protected override async Task FillWeightUnitAsync( IEnumerable< BigCommerceProduct > products, CancellationToken token, string marker )
 		{
 			var store = await ActionPolicies.GetAsync.Get( async () =>
 				await this._webRequestServices.GetResponseAsync< BigCommerceStore >( BigCommerceCommand.GetStoreV2, string.Empty, marker ) );
@@ -102,7 +102,7 @@ namespace BigCommerceAccess
 			}
 		}
 
-		private void FillBrands( IEnumerable< BigCommerceProduct > products, string marker )
+		protected override void FillBrands( IEnumerable< BigCommerceProduct > products, string marker )
 		{
 			var brands = new List< BigCommerceBrand >();
 			for( var i = 1; i < int.MaxValue; i++ )
@@ -123,7 +123,7 @@ namespace BigCommerceAccess
 			this.FillBrandsForProducts( products, brands );
 		}
 
-		private async Task FillBrandsAsync( IEnumerable< BigCommerceProduct > products, CancellationToken token, string marker )
+		protected override async Task FillBrandsAsync( IEnumerable< BigCommerceProduct > products, CancellationToken token, string marker )
 		{
 			var brands = new List< BigCommerceBrand >();
 			for( var i = 1; i < int.MaxValue; i++ )

--- a/src/BigCommerceAccess/BigCommerceProductsServiceV2OAuth.cs
+++ b/src/BigCommerceAccess/BigCommerceProductsServiceV2OAuth.cs
@@ -42,8 +42,8 @@ namespace BigCommerceAccess
 
 			if( includeExtendInfo )
 			{
-				this.FillWeightUnit( products, marker );
-				this.FillBrands( products, marker );
+				base.FillWeightUnit( products, marker );
+				base.FillBrands( products, marker );
 			}
 
 			return products;
@@ -73,77 +73,11 @@ namespace BigCommerceAccess
 
 			if( includeExtendedInfo )
 			{
-				await this.FillWeightUnitAsync( products, token, marker );
-				await this.FillBrandsAsync( products, token, marker );
+				await base.FillWeightUnitAsync( products, token, marker );
+				await base.FillBrandsAsync( products, token, marker );
 			}
 
 			return products;
-		}
-
-		public void FillWeightUnit( IEnumerable< BigCommerceProduct > products, string marker )
-		{
-			var store = ActionPolicies.Get.Get( () =>
-				this._webRequestServices.GetResponse< BigCommerceStore >( BigCommerceCommand.GetStoreV2_OAuth, string.Empty, marker ) );
-			this.CreateApiDelay( store.Limits ).Wait(); //API requirement
-
-			foreach( var product in products )
-			{
-				product.WeightUnit = store.Response.WeightUnits;
-			}
-		}
-
-		public async Task FillWeightUnitAsync( IEnumerable< BigCommerceProduct > products, CancellationToken token, string marker )
-		{
-			var store = await ActionPolicies.GetAsync.Get( async () =>
-				await this._webRequestServices.GetResponseAsync< BigCommerceStore >( BigCommerceCommand.GetStoreV2_OAuth, string.Empty, marker ) );
-			await this.CreateApiDelay( store.Limits, token ); //API requirement
-
-			foreach( var product in products )
-			{
-				product.WeightUnit = store.Response.WeightUnits;
-			}
-		}
-
-		public void FillBrands( IEnumerable< BigCommerceProduct > products, string marker )
-		{
-			var brands = new List< BigCommerceBrand >();
-			for( var i = 1; i < int.MaxValue; i++ )
-			{
-				var endpoint = ParamsBuilder.CreateGetNextPageParams( new BigCommerceCommandConfig( i, RequestMaxLimit ) );
-				var brandsWithinPage = ActionPolicies.Get.Get( () =>
-					this._webRequestServices.GetResponse< List< BigCommerceBrand > >( BigCommerceCommand.GetBrandsV2_OAuth, endpoint, marker ) );
-				this.CreateApiDelay( brandsWithinPage.Limits ).Wait(); //API requirement
-
-				if( brandsWithinPage.Response == null )
-					break;
-
-				brands.AddRange( brandsWithinPage.Response );
-				if( brandsWithinPage.Response.Count < RequestMaxLimit )
-					break;
-			}
-
-			this.FillBrandsForProducts( products, brands );
-		}
-
-		public async Task FillBrandsAsync( IEnumerable< BigCommerceProduct > products, CancellationToken token, string marker )
-		{
-			var brands = new List< BigCommerceBrand >();
-			for( var i = 1; i < int.MaxValue; i++ )
-			{
-				var endpoint = ParamsBuilder.CreateGetNextPageParams( new BigCommerceCommandConfig( i, RequestMaxLimit ) );
-				var brandsWithinPage = await ActionPolicies.GetAsync.Get( async () =>
-					await this._webRequestServices.GetResponseAsync< List< BigCommerceBrand > >( BigCommerceCommand.GetBrandsV2_OAuth, endpoint, marker ) );
-				await this.CreateApiDelay( brandsWithinPage.Limits, token ); //API requirement
-
-				if( brandsWithinPage.Response == null )
-					break;
-
-				brands.AddRange( brandsWithinPage.Response );
-				if( brandsWithinPage.Response.Count < RequestMaxLimit )
-					break;
-			}
-
-			this.FillBrandsForProducts( products, brands );
 		}
 		#endregion
 

--- a/src/BigCommerceAccess/BigCommerceProductsServiceV3.cs
+++ b/src/BigCommerceAccess/BigCommerceProductsServiceV3.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using BigCommerceAccess.Misc;
@@ -9,7 +7,6 @@ using BigCommerceAccess.Models.Command;
 using BigCommerceAccess.Models.Configuration;
 using BigCommerceAccess.Models.Product;
 using BigCommerceAccess.Services;
-using CuttingEdge.Conditions;
 using Netco.Extensions;
 using ServiceStack;
 
@@ -17,13 +14,8 @@ namespace BigCommerceAccess
 {
 	sealed class BigCommerceProductsServiceV3 : BigCommerceBaseProductsService, IBigCommerceProductsService
 	{
-		private readonly BigCommerceProductsServiceV2OAuth _productsServiceV2OAuth;
-
-		public BigCommerceProductsServiceV3( WebRequestServices services, BigCommerceProductsServiceV2OAuth productsServiceV2OAuth ) : base( services )
+		public BigCommerceProductsServiceV3( WebRequestServices services ) : base( services )
 		{
-			Condition.Requires( productsServiceV2OAuth, "_productsServiceV2OAuth" ).IsNotNull();
-
-			this._productsServiceV2OAuth = productsServiceV2OAuth;
 		}
 
 		#region Get
@@ -80,8 +72,8 @@ namespace BigCommerceAccess
 
 			if( includeExtendedInfo )
 			{
-				this._productsServiceV2OAuth.FillWeightUnit( products, marker );
-				this._productsServiceV2OAuth.FillBrands( products, marker );
+				base.FillWeightUnit( products, marker );
+				base.FillBrands( products, marker );
 			}
 
 			return products;
@@ -135,8 +127,8 @@ namespace BigCommerceAccess
 
 			if( includeExtendedInfo )
 			{
-				await this._productsServiceV2OAuth.FillWeightUnitAsync( products, token, marker );
-				await this._productsServiceV2OAuth.FillBrandsAsync( products, token, marker );
+				await base.FillWeightUnitAsync( products, token, marker );
+				await base.FillBrandsAsync( products, token, marker );
 			}
 
 			return products;

--- a/src/BigCommerceAccess/BigCommerceProductsServiceV3.cs
+++ b/src/BigCommerceAccess/BigCommerceProductsServiceV3.cs
@@ -14,6 +14,8 @@ namespace BigCommerceAccess
 {
 	sealed class BigCommerceProductsServiceV3 : BigCommerceBaseProductsService, IBigCommerceProductsService
 	{
+		private const string _inventoryTrackingByOption = "variant";
+
 		public BigCommerceProductsServiceV3( WebRequestServices services ) : base( services )
 		{
 		}
@@ -39,7 +41,7 @@ namespace BigCommerceAccess
 					products.Add( new BigCommerceProduct
 					{
 						Id = product.Id,
-						InventoryTracking = product.InventoryTracking.ToEnum( InventoryTrackingEnum.none ),
+						InventoryTracking = this.ToCompatibleWithV2InventoryTrackingEnum( product.InventoryTracking ),
 						Upc = product.Upc,
 						Sku = product.Sku,
 						Name = product.Name,
@@ -100,7 +102,7 @@ namespace BigCommerceAccess
 					{
 						Id = product.Id,
 						Sku = product.Sku,
-						InventoryTracking = product.InventoryTracking.ToEnum( InventoryTrackingEnum.none ),
+						InventoryTracking = this.ToCompatibleWithV2InventoryTrackingEnum( product.InventoryTracking ),
 						Upc = product.Upc,
 						Name = product.Name,
 						Description = product.Description,
@@ -110,11 +112,14 @@ namespace BigCommerceAccess
 						CostPrice = product.CostPrice,
 						Weight = product.Weight,
 						BrandId = product.BrandId,
+						Quantity = product.Quantity,
 						ImageUrls = new BigCommerceProductPrimaryImages { StandardUrl = product.Images.FirstOrDefault() != null ? product.Images.FirstOrDefault().UrlStandard : string.Empty },
 						ProductOptions = product.Variants.Select( x => new BigCommerceProductOption
 						{
+							Id = x.Id,
 							ProductId = x.ProductId,
 							Sku = x.Sku,
+							Quantity = x.Quantity,
 							Upc = x.Upc,
 							Price = x.Price,
 							CostPrice = x.CostPrice,
@@ -199,6 +204,23 @@ namespace BigCommerceAccess
 			} );
 		}
 
+		#endregion
+
+		#region Misc
+		private InventoryTrackingEnum ToCompatibleWithV2InventoryTrackingEnum( string inventoryTracking )
+		{
+			if ( string.IsNullOrWhiteSpace( inventoryTracking ) )
+			{
+				return InventoryTrackingEnum.none;
+			}
+
+			if ( inventoryTracking.Equals( _inventoryTrackingByOption ) )
+			{
+				return InventoryTrackingEnum.sku;
+			}
+
+			return InventoryTrackingEnum.simple;
+		}
 		#endregion
 	}
 }

--- a/src/BigCommerceAccess/BigCommerceProductsServiceV3.cs
+++ b/src/BigCommerceAccess/BigCommerceProductsServiceV3.cs
@@ -99,6 +99,7 @@ namespace BigCommerceAccess
 					products.Add( new BigCommerceProduct
 					{
 						Id = product.Id,
+						Sku = product.Sku,
 						InventoryTracking = product.InventoryTracking.ToEnum( InventoryTrackingEnum.none ),
 						Upc = product.Upc,
 						Name = product.Name,
@@ -113,6 +114,7 @@ namespace BigCommerceAccess
 						ProductOptions = product.Variants.Select( x => new BigCommerceProductOption
 						{
 							ProductId = x.ProductId,
+							Sku = x.Sku,
 							Upc = x.Upc,
 							Price = x.Price,
 							CostPrice = x.CostPrice,

--- a/src/BigCommerceAccessTests/Products/ProductsTests.cs
+++ b/src/BigCommerceAccessTests/Products/ProductsTests.cs
@@ -76,6 +76,22 @@ namespace BigCommerceAccessTests.Products
 		}
 
 		[ Test ]
+		public void ProductShouldHaveEnabledTrackingInventoryByProduct()
+		{
+			var product = this.GetProductBySkuV3( this.testProductSku );
+
+			product.InventoryTracking.Should().Be( InventoryTrackingEnum.simple );
+		}
+
+		[ Test ]
+		public void ProductShouldHaveEnabledTrackingInventoryByOption()
+		{
+			var product = this.GetProductBySkuV3( this.testProductWithOptionsSku );
+
+			product.InventoryTracking.Should().Be( InventoryTrackingEnum.sku );
+		}
+
+		[ Test ]
 		public void ProductsQuantityUpdatedV2()
 		{
 			var service = this.BigCommerceFactory.CreateProductsService( this.ConfigV2 );

--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -24,4 +24,4 @@ using System.Runtime.InteropServices;
 
 // Keep in track with CA API version
 
-[ assembly : AssemblyVersion( "1.0.42.0" ) ]
+[ assembly : AssemblyVersion( "1.0.43.0" ) ]

--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -24,4 +24,4 @@ using System.Runtime.InteropServices;
 
 // Keep in track with CA API version
 
-[ assembly : AssemblyVersion( "1.0.41.0" ) ]
+[ assembly : AssemblyVersion( "1.0.42.0" ) ]


### PR DESCRIPTION
Summary
Switched product pulling to V3 Catalog API (https://developer.bigcommerce.com/legacy/v2-products/v2-v3). Also refactored huge BigCommerceProductsService class to three different BigCommerceProductServices classes where each of them responsible for working with concrete API version.