### PR TITLE
2020-01-23 GUARD-379 Pictures-Not-Pull

### DIFF
--- a/src/BigCommerceAccess/BigCommerceProductsServiceV3.cs
+++ b/src/BigCommerceAccess/BigCommerceProductsServiceV3.cs
@@ -23,7 +23,7 @@ namespace BigCommerceAccess
 		#region Get
 		public List< BigCommerceProduct > GetProducts( bool includeExtendedInfo )
 		{
-			var mainEndpoint = "?include=variants";
+			var mainEndpoint = "?include=variants,images";
 			var products = new List< BigCommerceProduct >();
 			var marker = this.GetMarker();
 
@@ -83,7 +83,7 @@ namespace BigCommerceAccess
 
 		public async Task< List< BigCommerceProduct > > GetProductsAsync( CancellationToken token, bool includeExtendedInfo )
 		{
-			var mainEndpoint = "?include=variants";
+			var mainEndpoint = "?include=variants,images";
 			var products = new List< BigCommerceProduct >();
 			var marker = this.GetMarker();
 

--- a/src/BigCommerceAccessTests/Products/ProductsTests.cs
+++ b/src/BigCommerceAccessTests/Products/ProductsTests.cs
@@ -67,12 +67,34 @@ namespace BigCommerceAccessTests.Products
 		}
 
 		[ Test ]
+		public void GetProductsImagesV3()
+		{
+			var service = this.BigCommerceFactory.CreateProductsService( this.ConfigV3 );
+			var products = service.GetProducts();
+
+			products.Count().Should().BeGreaterThan( 0 );
+			var productWithImages = products.Where( pr => pr.ImageUrls != null && !string.IsNullOrWhiteSpace( pr.ImageUrls.StandardUrl ) );
+			productWithImages.Count().Should().BeGreaterThan( 0 );
+		}
+
+		[ Test ]
 		public async Task GetProductsV3Async()
 		{
 			var service = this.BigCommerceFactory.CreateProductsService( this.ConfigV3 );
 			var products = await service.GetProductsAsync( CancellationToken.None );
 
 			products.Count().Should().BeGreaterThan( 0 );
+		}
+
+		[ Test ]
+		public async Task GetProductsImagesV3Async()
+		{
+			var service = this.BigCommerceFactory.CreateProductsService( this.ConfigV3 );
+			var products = await service.GetProductsAsync( CancellationToken.None );
+			
+			products.Count().Should().BeGreaterThan( 0 );
+			var productWithImages = products.Where( pr => pr.ImageUrls != null && !string.IsNullOrWhiteSpace( pr.ImageUrls.StandardUrl ) );
+			productWithImages.Count().Should().BeGreaterThan( 0 );
 		}
 
 		[ Test ]

--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 [ assembly : ComVisible( false ) ]
 [ assembly : AssemblyProduct( "BigCommerceAccess" ) ]
 [ assembly : AssemblyCompany( "SkuVault Inc." ) ]
-[ assembly : AssemblyCopyright( "Copyright (C) 2019 SkuVault Inc." ) ]
+[ assembly : AssemblyCopyright( "Copyright (C) 2020 SkuVault Inc." ) ]
 [ assembly : AssemblyDescription( "BigCommerce webservices API wrapper." ) ]
 [ assembly : AssemblyTrademark( "" ) ]
 [ assembly : AssemblyCulture( "" ) ]
@@ -24,4 +24,4 @@ using System.Runtime.InteropServices;
 
 // Keep in track with CA API version
 
-[ assembly : AssemblyVersion( "1.1.4.0" ) ]
+[ assembly : AssemblyVersion( "1.1.5.0" ) ]


### PR DESCRIPTION
**Summary**

After moving to V3 API product image pulling suddenly stopped working. In comparison with previous API version now product's images including should be specified using the correspondent parameter.