### PR TITLE
2020-02-06 GUARD-394 Products-Pulling-Error

### DIFF
--- a/src/BigCommerceAccess/BigCommerceProductsServiceV3.cs
+++ b/src/BigCommerceAccess/BigCommerceProductsServiceV3.cs
@@ -41,8 +41,10 @@ namespace BigCommerceAccess
 						if ( webEx.Status == WebExceptionStatus.ConnectionClosed )
 						{
 							// gracefully decrease products page size
-							int newRequestMaxLimit = (int)Math.Floor( this.RequestMaxLimit / 2d );
-							i = (int)Math.Floor( ( ( i - 1 ) * this.RequestMaxLimit * 1.0 ) / newRequestMaxLimit ) + 1;
+							var productsLoaded = this.RequestMaxLimit * ( i - 1 );
+							var newRequestMaxLimit = (int)Math.Floor( this.RequestMaxLimit / 2d );
+							
+							i = (int)Math.Floor( productsLoaded / newRequestMaxLimit * 1.0 ) + 1;
 							this.RequestMaxLimit = newRequestMaxLimit;
 						}
 					}
@@ -119,8 +121,10 @@ namespace BigCommerceAccess
 						if ( webEx.Status == WebExceptionStatus.ConnectionClosed )
 						{
 							// gracefully decrease products page size
-							int newRequestMaxLimit = (int)Math.Floor( this.RequestMaxLimit / 2d );
-							i = (int)Math.Floor( ( ( i - 1 ) * this.RequestMaxLimit * 1.0 ) / newRequestMaxLimit ) + 1;
+							var productsLoaded = this.RequestMaxLimit * ( i - 1 );
+							var newRequestMaxLimit = (int)Math.Floor( this.RequestMaxLimit / 2d );
+							
+							i = (int)Math.Floor( productsLoaded / newRequestMaxLimit * 1.0 ) + 1;
 							this.RequestMaxLimit = newRequestMaxLimit;
 						}
 					}

--- a/src/BigCommerceAccess/BigCommerceProductsServiceV3.cs
+++ b/src/BigCommerceAccess/BigCommerceProductsServiceV3.cs
@@ -1,5 +1,7 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using BigCommerceAccess.Misc;
@@ -7,6 +9,7 @@ using BigCommerceAccess.Models.Command;
 using BigCommerceAccess.Models.Configuration;
 using BigCommerceAccess.Models.Product;
 using BigCommerceAccess.Services;
+using Netco.ActionPolicyServices;
 using Netco.Extensions;
 using ServiceStack;
 
@@ -29,9 +32,27 @@ namespace BigCommerceAccess
 
 			for( var i = 1; i < int.MaxValue; i++ )
 			{
-				var endpoint = mainEndpoint.ConcatParams( ParamsBuilder.CreateGetNextPageParams( new BigCommerceCommandConfig( i, RequestMaxLimit ) ) );
-				var productsWithinPage = ActionPolicies.Get.Get( () =>
-					base._webRequestServices.GetResponse< BigCommerceProductInfoData >( BigCommerceCommand.GetProductsV3, endpoint, marker ) );
+				var productsWithinPage = ActionPolicy.Handle< Exception >().Retry( ActionPolicies.RetryCount, ( ex, retryAttempt ) =>
+				{
+					var webEx = ex?.InnerException as WebException;
+
+					if ( webEx != null )
+					{
+						if ( webEx.Status == WebExceptionStatus.ConnectionClosed )
+						{
+							// gracefully decrease products page size
+							int newRequestMaxLimit = (int)Math.Floor( this.RequestMaxLimit / 2d );
+							i = (int)Math.Floor( ( ( i - 1 ) * this.RequestMaxLimit * 1.0 ) / newRequestMaxLimit ) + 1;
+							this.RequestMaxLimit = newRequestMaxLimit;
+						}
+					}
+
+					ActionPolicies.LogRetryAndWait( ex, retryAttempt );
+				} ).Get( () => {
+					var endpoint = mainEndpoint.ConcatParams( ParamsBuilder.CreateGetNextPageParams( new BigCommerceCommandConfig( i, RequestMaxLimit ) ) );
+					return this._webRequestServices.GetResponse< BigCommerceProductInfoData >( BigCommerceCommand.GetProductsV3, endpoint, marker ); 
+				} );
+				
 				this.CreateApiDelay( productsWithinPage.Limits ).Wait(); //API requirement
 
 				if( productsWithinPage.Response == null )
@@ -89,9 +110,27 @@ namespace BigCommerceAccess
 
 			for( var i = 1; i < int.MaxValue; i++ )
 			{
-				var endpoint = mainEndpoint.ConcatParams( ParamsBuilder.CreateGetNextPageParams( new BigCommerceCommandConfig( i, RequestMaxLimit ) ) );
-				var productsWithinPage = await ActionPolicies.GetAsync.Get( async () =>
-					await this._webRequestServices.GetResponseAsync< BigCommerceProductInfoData >( BigCommerceCommand.GetProductsV3, endpoint, marker ) );
+				var productsWithinPage = await ActionPolicyAsync.Handle< Exception >().RetryAsync( ActionPolicies.RetryCount, ( ex, retryAttempt ) =>
+				{
+					var webEx = ex?.InnerException as WebException;
+
+					if ( webEx != null )
+					{
+						if ( webEx.Status == WebExceptionStatus.ConnectionClosed )
+						{
+							// gracefully decrease products page size
+							int newRequestMaxLimit = (int)Math.Floor( this.RequestMaxLimit / 2d );
+							i = (int)Math.Floor( ( ( i - 1 ) * this.RequestMaxLimit * 1.0 ) / newRequestMaxLimit ) + 1;
+							this.RequestMaxLimit = newRequestMaxLimit;
+						}
+					}
+
+					return ActionPolicies.LogRetryAndWaitAsync( ex, retryAttempt );
+				} ).Get( () => {
+					var endpoint = mainEndpoint.ConcatParams( ParamsBuilder.CreateGetNextPageParams( new BigCommerceCommandConfig( i, RequestMaxLimit ) ) );
+					return this._webRequestServices.GetResponseAsync< BigCommerceProductInfoData >( BigCommerceCommand.GetProductsV3, endpoint, marker ); 
+				} );
+				
 				await this.CreateApiDelay( productsWithinPage.Limits, token ); //API requirement
 
 				if( productsWithinPage.Response == null )

--- a/src/BigCommerceAccess/BigCommerceProductsServiceV3.cs
+++ b/src/BigCommerceAccess/BigCommerceProductsServiceV3.cs
@@ -34,7 +34,7 @@ namespace BigCommerceAccess
 			{
 				var productsWithinPage = ActionPolicy.Handle< Exception >().Retry( ActionPolicies.RetryCount, ( ex, retryAttempt ) =>
 				{
-					var webEx = ex?.InnerException as WebException;
+					var webEx = ex.InnerException as WebException;
 
 					if ( webEx != null )
 					{
@@ -114,7 +114,7 @@ namespace BigCommerceAccess
 			{
 				var productsWithinPage = await ActionPolicyAsync.Handle< Exception >().RetryAsync( ActionPolicies.RetryCount, ( ex, retryAttempt ) =>
 				{
-					var webEx = ex?.InnerException as WebException;
+					var webEx = ex.InnerException as WebException;
 
 					if ( webEx != null )
 					{

--- a/src/BigCommerceAccess/BigCommerceServiceBase.cs
+++ b/src/BigCommerceAccess/BigCommerceServiceBase.cs
@@ -11,7 +11,7 @@ namespace BigCommerceAccess
 		//we need to grant not more than 5 api calls per second
 		//to have 18000 per hour and 2000 calls for the retry needs
 		private readonly TimeSpan DefaultApiDelay = TimeSpan.FromMilliseconds( 200 );
-		protected const int RequestMaxLimit = 250;
+		protected int RequestMaxLimit = 250;
 		protected const int MaxThreadsCount = 5;
 
 		protected Task CreateApiDelay( IBigCommerceRateLimits limits )

--- a/src/BigCommerceAccess/Misc/ActionPolicies.cs
+++ b/src/BigCommerceAccess/Misc/ActionPolicies.cs
@@ -8,9 +8,9 @@ namespace BigCommerceAccess.Misc
 	public static class ActionPolicies
 	{
 #if DEBUG
-		private const int RetryCount = 1;
+		public const int RetryCount = 1;
 #else
-		private const int RetryCount = 10;
+		public const int RetryCount = 10;
 #endif
 
 		public static readonly ActionPolicy Submit = ActionPolicy.Handle< Exception >().Retry( RetryCount, ( ex, i ) =>
@@ -25,16 +25,20 @@ namespace BigCommerceAccess.Misc
 			await Task.Delay( TimeSpan.FromSeconds( 5 + 20 * i ) );
 		} );
 
-		public static readonly ActionPolicy Get = ActionPolicy.Handle< Exception >().Retry( RetryCount, ( ex, i ) =>
-		{
-			BigCommerceLogger.Log.Trace( ex, "Retrying BigCommerce API get call for the {0} time", i );
-			SystemUtil.Sleep( TimeSpan.FromSeconds( 5 + 20 * i ) );
-		} );
+		public static readonly ActionPolicy Get = ActionPolicy.Handle< Exception >().Retry( RetryCount, LogRetryAndWait );
 
-		public static readonly ActionPolicyAsync GetAsync = ActionPolicyAsync.Handle< Exception >().RetryAsync( RetryCount, async ( ex, i ) =>
+		public static readonly ActionPolicyAsync GetAsync = ActionPolicyAsync.Handle< Exception >().RetryAsync( RetryCount, LogRetryAndWaitAsync );
+
+		public static void LogRetryAndWait( Exception ex, int retryAttempt )
 		{
-			BigCommerceLogger.Log.Trace( ex, "Retrying BigCommerce API get call for the {0} time", i );
-			await Task.Delay( TimeSpan.FromSeconds( 5 + 20 * i ) );
-		} );
+			BigCommerceLogger.Log.Trace( ex, "Retrying BigCommerce API get call for the {0} time", retryAttempt );
+			SystemUtil.Sleep( TimeSpan.FromSeconds( 5 + 20 * retryAttempt ) );
+		}
+
+		public static async Task LogRetryAndWaitAsync( Exception ex, int retryAttempt )
+		{
+			BigCommerceLogger.Log.Trace( ex, "Retrying BigCommerce API get call for the {0} time", retryAttempt );
+			await Task.Delay( TimeSpan.FromSeconds( 5 + 20 * retryAttempt ) );
+		}
 	}
 }

--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 [ assembly : ComVisible( false ) ]
 [ assembly : AssemblyProduct( "BigCommerceAccess" ) ]
 [ assembly : AssemblyCompany( "SkuVault Inc." ) ]
-[ assembly : AssemblyCopyright( "Copyright (C) 2019 SkuVault Inc." ) ]
+[ assembly : AssemblyCopyright( "Copyright (C) 2020 SkuVault Inc." ) ]
 [ assembly : AssemblyDescription( "BigCommerce webservices API wrapper." ) ]
 [ assembly : AssemblyTrademark( "" ) ]
 [ assembly : AssemblyCulture( "" ) ]
@@ -24,4 +24,4 @@ using System.Runtime.InteropServices;
 
 // Keep in track with CA API version
 
-[ assembly : AssemblyVersion( "1.1.4.0" ) ]
+[ assembly : AssemblyVersion( "1.1.6.0" ) ]


### PR DESCRIPTION
**Summary**
During the product pulling BigCommerce's server can immediately close connection. If requested number of products per page is decreased on our side the issue disappears. Using V3 catalog API we can include in one response also all product's variations. Some customer's products has more than 250 variations. I guess the reason of such weird behavior from BigCommerce server is too big response. I added dynamic product page size changing in case of such error.