### PR TITLE
2020-04-01 GUARD-483 Pulling-Incorrect-Product-Pictures

### DIFF
--- a/src/BigCommerceAccess/BigCommerceProductsServiceV3.cs
+++ b/src/BigCommerceAccess/BigCommerceProductsServiceV3.cs
@@ -61,6 +61,9 @@ namespace BigCommerceAccess
 					break;
 
 				foreach( var product in productsWithinPage.Response.Data )
+				{
+					var productImage = product.Images.FirstOrDefault( img => img.IsThumbnail );
+
 					products.Add( new BigCommerceProduct
 					{
 						Id = product.Id,
@@ -76,7 +79,10 @@ namespace BigCommerceAccess
 						Weight = product.Weight,
 						BrandId = product.BrandId,
 						Quantity = product.Quantity,
-						ImageUrls = new BigCommerceProductPrimaryImages { StandardUrl = product.Images.FirstOrDefault() != null ? product.Images.FirstOrDefault().UrlStandard : string.Empty },
+						ImageUrls = new BigCommerceProductPrimaryImages()
+						{ 
+							StandardUrl = productImage != null ? productImage.UrlStandard : string.Empty
+						},
 						ProductOptions = product.Variants.Select( x => new BigCommerceProductOption
 						{
 							Id = x.Id,
@@ -90,6 +96,7 @@ namespace BigCommerceAccess
 							ImageFile = x.ImageUrl
 						} ).ToList()
 					} );
+				}
 
 				if( productsWithinPage.Response.Data.Count < RequestMaxLimit )
 					break;
@@ -141,6 +148,9 @@ namespace BigCommerceAccess
 					break;
 
 				foreach( var product in productsWithinPage.Response.Data )
+				{
+					var productImage = product.Images.FirstOrDefault( img => img.IsThumbnail );
+
 					products.Add( new BigCommerceProduct
 					{
 						Id = product.Id,
@@ -156,7 +166,10 @@ namespace BigCommerceAccess
 						Weight = product.Weight,
 						BrandId = product.BrandId,
 						Quantity = product.Quantity,
-						ImageUrls = new BigCommerceProductPrimaryImages { StandardUrl = product.Images.FirstOrDefault() != null ? product.Images.FirstOrDefault().UrlStandard : string.Empty },
+						ImageUrls = new BigCommerceProductPrimaryImages()
+						{ 
+							StandardUrl = productImage != null ? productImage.UrlStandard : string.Empty
+						},
 						ProductOptions = product.Variants.Select( x => new BigCommerceProductOption
 						{
 							Id = x.Id,
@@ -170,6 +183,7 @@ namespace BigCommerceAccess
 							ImageFile = x.ImageUrl
 						} ).ToList()
 					} );
+				}
 
 				if( productsWithinPage.Response.Data.Count < RequestMaxLimit )
 					break;

--- a/src/BigCommerceAccess/Models/Product/BigCommerceImage.cs
+++ b/src/BigCommerceAccess/Models/Product/BigCommerceImage.cs
@@ -8,5 +8,8 @@ namespace BigCommerceAccess.Models.Product
 	{
 		[ DataMember( Name = "url_standard" ) ]
 		public string UrlStandard{ get; set; }
+
+		[ DataMember( Name = "is_thumbnail" ) ]
+		public bool IsThumbnail { get; set; }
 	}
 }

--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -24,4 +24,4 @@ using System.Runtime.InteropServices;
 
 // Keep in track with CA API version
 
-[ assembly : AssemblyVersion( "1.1.6.0" ) ]
+[ assembly : AssemblyVersion( "1.1.7.0" ) ]


### PR DESCRIPTION
Summary
Now products sync pulls only thumbnail pictures.