### PR TITLE
2021-05-01 GUARD-752 GUARD-805 BigCommerce-Integration-Review

### DIFF
--- a/.build.ps1
+++ b/.build.ps1
@@ -22,7 +22,7 @@ $src_dir = "$BuildRoot\src"
 $solution_file = "$src_dir\$($project_name).sln"
 	
 # Use MSBuild.
-use Framework\v4.0.30319 MSBuild
+Set-Alias MSBuild (Join-Path -Path (Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\MSBuild\ToolsVersions\14.0").MSBuildToolsPath -ChildPath "MSBuild.exe")
 
 task Clean { 
 	exec { MSBuild "$solution_file" /t:Clean /p:Configuration=Release /p:Platform="Any CPU" /v:quiet } 

--- a/src/BigCommerceAccess/BigCommerceAccess.csproj
+++ b/src/BigCommerceAccess/BigCommerceAccess.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/src/BigCommerceAccess/BigCommerceAccess.csproj
+++ b/src/BigCommerceAccess/BigCommerceAccess.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -35,9 +35,8 @@
     <Reference Include="CuttingEdge.Conditions">
       <HintPath>..\packages\CuttingEdge.Conditions.1.2.0.0\lib\NET35\CuttingEdge.Conditions.dll</HintPath>
     </Reference>
-    <Reference Include="Netco, Version=1.5.5.0, Culture=neutral, PublicKeyToken=9d732c15ac2ec2c9, processorArchitecture=MSIL">
-      <HintPath>..\packages\Netco.1.5.5\lib\net45\Netco.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Netco, Version=1.5.8.0, Culture=neutral, PublicKeyToken=9d732c15ac2ec2c9, processorArchitecture=MSIL">
+      <HintPath>..\packages\Netco.1.5.8\lib\net45\Netco.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=8.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -67,6 +66,7 @@
     <Compile Include="IBigCommerceProductsService.cs" />
     <Compile Include="Misc\ActionPolicies.cs" />
     <Compile Include="Misc\BigCommerceLogger.cs" />
+    <Compile Include="Misc\CallInfo.cs" />
     <Compile Include="Models\BigCommerceObjectBase.cs" />
     <Compile Include="Models\Order\BigCommerceOrderCoupon.cs" />
     <Compile Include="Models\Product\BigCommerceProductInfoData.cs" />

--- a/src/BigCommerceAccess/BigCommerceBaseProductsService.cs
+++ b/src/BigCommerceAccess/BigCommerceBaseProductsService.cs
@@ -25,8 +25,9 @@ namespace BigCommerceAccess
 
 		protected virtual void FillWeightUnit( IEnumerable< BigCommerceProduct > products, string marker )
 		{
-			var store = ActionPolicies.Get.Get( () =>
-				this._webRequestServices.GetResponse< BigCommerceStore >( BigCommerceCommand.GetStoreV2_OAuth, string.Empty, marker ) );
+			var command = BigCommerceCommand.GetStoreV2_OAuth;
+			var store = ActionPolicies.Get( marker, command.Command ).Get( () =>
+				this._webRequestServices.GetResponseByRelativeUrl< BigCommerceStore >( command, string.Empty, marker ) );
 			this.CreateApiDelay( store.Limits ).Wait(); //API requirement
 
 			foreach( var product in products )
@@ -37,8 +38,9 @@ namespace BigCommerceAccess
 
 		protected virtual async Task FillWeightUnitAsync( IEnumerable< BigCommerceProduct > products, CancellationToken token, string marker )
 		{
-			var store = await ActionPolicies.GetAsync.Get( async () =>
-				await this._webRequestServices.GetResponseAsync< BigCommerceStore >( BigCommerceCommand.GetStoreV2_OAuth, string.Empty, marker ) );
+			var command = BigCommerceCommand.GetStoreV2_OAuth;
+			var store = await ActionPolicies.GetAsync( marker, command.Command ).Get( async () =>
+				await this._webRequestServices.GetResponseByRelativeUrlAsync< BigCommerceStore >( command, string.Empty, marker ) );
 			await this.CreateApiDelay( store.Limits, token ); //API requirement
 
 			foreach( var product in products )
@@ -53,8 +55,8 @@ namespace BigCommerceAccess
 			for( var i = 1; i < int.MaxValue; i++ )
 			{
 				var endpoint = ParamsBuilder.CreateGetNextPageParams( new BigCommerceCommandConfig( i, RequestMaxLimit ) );
-				var brandsWithinPage = ActionPolicies.Get.Get( () =>
-					this._webRequestServices.GetResponse< List< BigCommerceBrand > >( BigCommerceCommand.GetBrandsV2_OAuth, endpoint, marker ) );
+				var brandsWithinPage = ActionPolicies.Get( marker, endpoint ).Get( () =>
+					this._webRequestServices.GetResponseByRelativeUrl< List< BigCommerceBrand > >( BigCommerceCommand.GetBrandsV2_OAuth, endpoint, marker ) );
 				this.CreateApiDelay( brandsWithinPage.Limits ).Wait(); //API requirement
 
 				if( brandsWithinPage.Response == null )
@@ -74,8 +76,8 @@ namespace BigCommerceAccess
 			for( var i = 1; i < int.MaxValue; i++ )
 			{
 				var endpoint = ParamsBuilder.CreateGetNextPageParams( new BigCommerceCommandConfig( i, RequestMaxLimit ) );
-				var brandsWithinPage = await ActionPolicies.GetAsync.Get( async () =>
-					await this._webRequestServices.GetResponseAsync< List< BigCommerceBrand > >( BigCommerceCommand.GetBrandsV2_OAuth, endpoint, marker ) );
+				var brandsWithinPage = await ActionPolicies.GetAsync( marker, endpoint ).Get( async () =>
+					await this._webRequestServices.GetResponseByRelativeUrlAsync< List< BigCommerceBrand > >( BigCommerceCommand.GetBrandsV2_OAuth, endpoint, marker ) );
 				await this.CreateApiDelay( brandsWithinPage.Limits, token ); //API requirement
 
 				if( brandsWithinPage.Response == null )
@@ -96,8 +98,8 @@ namespace BigCommerceAccess
 				for( var i = 1; i < int.MaxValue; i++ )
 				{
 					var endpoint = ParamsBuilder.CreateGetNextPageParams( new BigCommerceCommandConfig( i, RequestMaxLimit ) );
-					var options = ActionPolicies.Get.Get( () =>
-						this._webRequestServices.GetResponse< List< BigCommerceProductOption > >( product.ProductOptionsReference.Url, endpoint, marker ) );
+					var options = ActionPolicies.Get( marker, endpoint ).Get( () =>
+						this._webRequestServices.GetResponseByRelativeUrl< List< BigCommerceProductOption > >( product.ProductOptionsReference.Url, endpoint, marker ) );
 					this.CreateApiDelay( options.Limits ).Wait(); //API requirement
 
 					if( options.Response == null )
@@ -118,8 +120,8 @@ namespace BigCommerceAccess
 				for( var i = 1; i < int.MaxValue; i++ )
 				{
 					var endpoint = ParamsBuilder.CreateGetNextPageParams( new BigCommerceCommandConfig( i, RequestMaxLimit ) );
-					var options = await ActionPolicies.GetAsync.Get( async () =>
-						await this._webRequestServices.GetResponseAsync< List< BigCommerceProductOption > >( product.ProductOptionsReference.Url, endpoint, marker ) );
+					var options = await ActionPolicies.GetAsync( marker, endpoint ).Get( async () =>
+						await this._webRequestServices.GetResponseByRelativeUrlAsync< List< BigCommerceProductOption > >( product.ProductOptionsReference.Url, endpoint, marker ) );
 					await this.CreateApiDelay( options.Limits, token ); //API requirement
 
 					if( options.Response == null )

--- a/src/BigCommerceAccess/BigCommerceOrdersService.cs
+++ b/src/BigCommerceAccess/BigCommerceOrdersService.cs
@@ -45,8 +45,8 @@ namespace BigCommerceAccess
 			for( var i = 1; i < int.MaxValue; i++ )
 			{
 				var compositeEndpoint = mainEndpoint.ConcatParams( ParamsBuilder.CreateGetNextPageParams( new BigCommerceCommandConfig( i, RequestMaxLimit ) ) );
-				var ordersWithinPage = ActionPolicies.Get.Get( () =>
-					this._webRequestServices.GetResponse< List< BigCommerceOrder > >( BigCommerceCommand.GetOrdersV2, compositeEndpoint, marker ) );
+				var ordersWithinPage = ActionPolicies.Get( marker, compositeEndpoint ).Get( () =>
+					this._webRequestServices.GetResponseByRelativeUrl< List< BigCommerceOrder > >( BigCommerceCommand.GetOrdersV2, compositeEndpoint, marker ) );
 				this.CreateApiDelay( ordersWithinPage.Limits ).Wait(); //API requirement
 
 				if( ordersWithinPage.Response == null )
@@ -72,8 +72,8 @@ namespace BigCommerceAccess
 			for( var i = 1; i < int.MaxValue; i++ )
 			{
 				var compositeEndpoint = mainEndpoint.ConcatParams( ParamsBuilder.CreateGetNextPageParams( new BigCommerceCommandConfig( i, RequestMaxLimit ) ) );
-				var ordersWithinPage = ActionPolicies.Get.Get( () =>
-					this._webRequestServices.GetResponse< List< BigCommerceOrder > >( BigCommerceCommand.GetOrdersV2_OAuth, compositeEndpoint, marker ) );
+				var ordersWithinPage = ActionPolicies.Get( marker, compositeEndpoint ).Get( () =>
+					this._webRequestServices.GetResponseByRelativeUrl< List< BigCommerceOrder > >( BigCommerceCommand.GetOrdersV2_OAuth, compositeEndpoint, marker ) );
 				this.CreateApiDelay( ordersWithinPage.Limits ).Wait(); //API requirement
 
 				if( ordersWithinPage.Response == null )
@@ -99,8 +99,8 @@ namespace BigCommerceAccess
 			for( var i = 1; i < int.MaxValue; i++ )
 			{
 				var compositeEndpoint = mainEndpoint.ConcatParams( ParamsBuilder.CreateGetNextPageParams( new BigCommerceCommandConfig( i, RequestMaxLimit ) ) );
-				var ordersWithinPage = await ActionPolicies.GetAsync.Get( async () =>
-					await this._webRequestServices.GetResponseAsync< List< BigCommerceOrder > >( BigCommerceCommand.GetOrdersV2, compositeEndpoint, marker ) );
+				var ordersWithinPage = await ActionPolicies.GetAsync( marker, compositeEndpoint ).Get( async () =>
+					await this._webRequestServices.GetResponseByRelativeUrlAsync< List< BigCommerceOrder > >( BigCommerceCommand.GetOrdersV2, compositeEndpoint, marker ) );
 				await this.CreateApiDelay( ordersWithinPage.Limits, token ); //API requirement
 
 				if( ordersWithinPage.Response == null )
@@ -126,8 +126,8 @@ namespace BigCommerceAccess
 			for( var i = 1; i < int.MaxValue; i++ )
 			{
 				var compositeEndpoint = mainEndpoint.ConcatParams( ParamsBuilder.CreateGetNextPageParams( new BigCommerceCommandConfig( i, RequestMaxLimit ) ) );
-				var ordersWithinPage = await ActionPolicies.GetAsync.Get( async () =>
-					await this._webRequestServices.GetResponseAsync< List< BigCommerceOrder > >( BigCommerceCommand.GetOrdersV2_OAuth, compositeEndpoint, marker ) );
+				var ordersWithinPage = await ActionPolicies.GetAsync( marker, compositeEndpoint ).Get( async () =>
+					await this._webRequestServices.GetResponseByRelativeUrlAsync< List< BigCommerceOrder > >( BigCommerceCommand.GetOrdersV2_OAuth, compositeEndpoint, marker ) );
 				await this.CreateApiDelay( ordersWithinPage.Limits, token ); //API requirement
 
 				if( ordersWithinPage.Response == null )
@@ -154,8 +154,8 @@ namespace BigCommerceAccess
 				for( var i = 1; i < int.MaxValue; i++ )
 				{
 					var endpoint = ParamsBuilder.CreateGetNextPageParams( new BigCommerceCommandConfig( i, RequestMaxLimit ) );
-					var products = ActionPolicies.Get.Get( () =>
-						this._webRequestServices.GetResponse< List< BigCommerceOrderProduct > >( order.ProductsReference.Url, endpoint, marker ) );
+					var products = ActionPolicies.Get( marker, endpoint ).Get( () =>
+						this._webRequestServices.GetResponseByRelativeUrl< List< BigCommerceOrderProduct > >( order.ProductsReference.Url, endpoint, marker ) );
 					this.CreateApiDelay( products.Limits ).Wait(); //API requirement
 
 					if( products.Response == null )
@@ -175,8 +175,8 @@ namespace BigCommerceAccess
 				for( var i = 1; i < int.MaxValue; i++ )
 				{
 					var endpoint = ParamsBuilder.CreateGetNextPageParams( new BigCommerceCommandConfig( i, RequestMaxLimit ) );
-					var products = await ActionPolicies.GetAsync.Get( async () =>
-						await this._webRequestServices.GetResponseAsync< List< BigCommerceOrderProduct > >( order.ProductsReference.Url, endpoint, marker ) );
+					var products = await ActionPolicies.GetAsync( marker, endpoint ).Get( async () =>
+						await this._webRequestServices.GetResponseByRelativeUrlAsync< List< BigCommerceOrderProduct > >( order.ProductsReference.Url, endpoint, marker ) );
 					await this.CreateApiDelay( products.Limits, token ); //API requirement
 
 					if( products.Response == null )
@@ -197,8 +197,8 @@ namespace BigCommerceAccess
 				for( var i = 1; i < int.MaxValue; i++ )
 				{
 					var endpoint = ParamsBuilder.CreateGetNextPageParams( new BigCommerceCommandConfig( i, RequestMaxLimit ) );
-					var coupons = ActionPolicies.Get.Get( () =>
-						this._webRequestServices.GetResponse< List< BigCommerceOrderCoupon > >( order.CouponsReference.Url, endpoint, marker ) );
+					var coupons = ActionPolicies.Get( marker, endpoint ).Get( () =>
+						this._webRequestServices.GetResponseByRelativeUrl< List< BigCommerceOrderCoupon > >( order.CouponsReference.Url, endpoint, marker ) );
 					this.CreateApiDelay( coupons.Limits ).Wait(); //API requirement
 
 					if( coupons.Response == null )
@@ -218,8 +218,8 @@ namespace BigCommerceAccess
 				for( var i = 1; i < int.MaxValue; i++ )
 				{
 					var endpoint = ParamsBuilder.CreateGetNextPageParams( new BigCommerceCommandConfig( i, RequestMaxLimit ) );
-					var coupons = await ActionPolicies.GetAsync.Get( async () =>
-						await this._webRequestServices.GetResponseAsync< List< BigCommerceOrderCoupon > >( order.CouponsReference.Url, endpoint, marker ) );
+					var coupons = await ActionPolicies.GetAsync( marker, endpoint ).Get( async () =>
+						await this._webRequestServices.GetResponseByRelativeUrlAsync< List< BigCommerceOrderCoupon > >( order.CouponsReference.Url, endpoint, marker ) );
 					await this.CreateApiDelay( coupons.Limits, token ); //API requirement
 
 					if( coupons.Response == null )
@@ -237,7 +237,7 @@ namespace BigCommerceAccess
 		{
 			foreach( var order in orders )
 			{
-				var addresses = ActionPolicies.Get.Get( () =>
+				var addresses = ActionPolicies.Get( marker, order.ShippingAddressesReference.Url ).Get( () =>
 					this._webRequestServices.GetResponse< List< BigCommerceShippingAddress > >( order.ShippingAddressesReference.Url, marker ) );
 				order.ShippingAddresses = addresses.Response;
 				this.CreateApiDelay( addresses.Limits ).Wait(); //API requirement
@@ -249,7 +249,7 @@ namespace BigCommerceAccess
 			var threadCount = isUnlimit ? MaxThreadsCount : 1;
 			await orders.DoInBatchAsync( threadCount, async order =>
 			{
-				var addresses = await ActionPolicies.GetAsync.Get( async () =>
+				var addresses = await ActionPolicies.GetAsync( marker, order.ShippingAddressesReference.Url).Get( async () =>
 					await this._webRequestServices.GetResponseAsync< List< BigCommerceShippingAddress > >( order.ShippingAddressesReference.Url, marker ) );
 				order.ShippingAddresses = addresses.Response;
 				await this.CreateApiDelay( addresses.Limits, token ); //API requirement

--- a/src/BigCommerceAccess/BigCommerceOrdersService.cs
+++ b/src/BigCommerceAccess/BigCommerceOrdersService.cs
@@ -153,6 +153,9 @@ namespace BigCommerceAccess
 			{
 				for( var i = 1; i < int.MaxValue; i++ )
 				{
+					if ( string.IsNullOrWhiteSpace( order.ProductsReference?.Url ) )
+						break;
+
 					var endpoint = ParamsBuilder.CreateGetNextPageParams( new BigCommerceCommandConfig( i, RequestMaxLimit ) );
 					var products = ActionPolicies.Get( marker, endpoint ).Get( () =>
 						this._webRequestServices.GetResponseByRelativeUrl< List< BigCommerceOrderProduct > >( order.ProductsReference.Url, endpoint, marker ) );
@@ -174,6 +177,9 @@ namespace BigCommerceAccess
 			{
 				for( var i = 1; i < int.MaxValue; i++ )
 				{
+					if ( string.IsNullOrWhiteSpace( order.ProductsReference?.Url ) )
+						break;
+
 					var endpoint = ParamsBuilder.CreateGetNextPageParams( new BigCommerceCommandConfig( i, RequestMaxLimit ) );
 					var products = await ActionPolicies.GetAsync( marker, endpoint ).Get( async () =>
 						await this._webRequestServices.GetResponseByRelativeUrlAsync< List< BigCommerceOrderProduct > >( order.ProductsReference.Url, endpoint, marker ) );
@@ -196,6 +202,9 @@ namespace BigCommerceAccess
 			{
 				for( var i = 1; i < int.MaxValue; i++ )
 				{
+					if ( string.IsNullOrWhiteSpace( order.CouponsReference?.Url ) )
+						break;
+
 					var endpoint = ParamsBuilder.CreateGetNextPageParams( new BigCommerceCommandConfig( i, RequestMaxLimit ) );
 					var coupons = ActionPolicies.Get( marker, endpoint ).Get( () =>
 						this._webRequestServices.GetResponseByRelativeUrl< List< BigCommerceOrderCoupon > >( order.CouponsReference.Url, endpoint, marker ) );
@@ -217,6 +226,9 @@ namespace BigCommerceAccess
 			{
 				for( var i = 1; i < int.MaxValue; i++ )
 				{
+					if ( string.IsNullOrWhiteSpace( order.CouponsReference?.Url ) )
+						break;
+
 					var endpoint = ParamsBuilder.CreateGetNextPageParams( new BigCommerceCommandConfig( i, RequestMaxLimit ) );
 					var coupons = await ActionPolicies.GetAsync( marker, endpoint ).Get( async () =>
 						await this._webRequestServices.GetResponseByRelativeUrlAsync< List< BigCommerceOrderCoupon > >( order.CouponsReference.Url, endpoint, marker ) );
@@ -237,6 +249,9 @@ namespace BigCommerceAccess
 		{
 			foreach( var order in orders )
 			{
+				if ( string.IsNullOrWhiteSpace( order.ShippingAddressesReference?.Url ) )
+					continue;
+
 				var addresses = ActionPolicies.Get( marker, order.ShippingAddressesReference.Url ).Get( () =>
 					this._webRequestServices.GetResponse< List< BigCommerceShippingAddress > >( order.ShippingAddressesReference.Url, marker ) );
 				order.ShippingAddresses = addresses.Response;
@@ -249,7 +264,10 @@ namespace BigCommerceAccess
 			var threadCount = isUnlimit ? MaxThreadsCount : 1;
 			await orders.DoInBatchAsync( threadCount, async order =>
 			{
-				var addresses = await ActionPolicies.GetAsync( marker, order.ShippingAddressesReference.Url).Get( async () =>
+				if ( string.IsNullOrWhiteSpace( order.ShippingAddressesReference?.Url ) )
+					return;
+
+				var addresses = await ActionPolicies.GetAsync( marker, order.ShippingAddressesReference.Url ).Get( async () =>
 					await this._webRequestServices.GetResponseAsync< List< BigCommerceShippingAddress > >( order.ShippingAddressesReference.Url, marker ) );
 				order.ShippingAddresses = addresses.Response;
 				await this.CreateApiDelay( addresses.Limits, token ); //API requirement

--- a/src/BigCommerceAccess/BigCommerceOrdersService.cs
+++ b/src/BigCommerceAccess/BigCommerceOrdersService.cs
@@ -200,11 +200,11 @@ namespace BigCommerceAccess
 		{
 			foreach( var order in orders )
 			{
+				if ( string.IsNullOrWhiteSpace( order.CouponsReference?.Url ) )
+					continue;
+
 				for( var i = 1; i < int.MaxValue; i++ )
 				{
-					if ( string.IsNullOrWhiteSpace( order.CouponsReference?.Url ) )
-						break;
-
 					var endpoint = ParamsBuilder.CreateGetNextPageParams( new BigCommerceCommandConfig( i, RequestMaxLimit ) );
 					var coupons = ActionPolicies.Get( marker, endpoint ).Get( () =>
 						this._webRequestServices.GetResponseByRelativeUrl< List< BigCommerceOrderCoupon > >( order.CouponsReference.Url, endpoint, marker ) );
@@ -224,11 +224,11 @@ namespace BigCommerceAccess
 			var threadCount = isUnlimit ? MaxThreadsCount : 1;
 			await orders.DoInBatchAsync( threadCount, async order =>
 			{
+				if ( string.IsNullOrWhiteSpace( order.CouponsReference?.Url ) )
+					return;
+
 				for( var i = 1; i < int.MaxValue; i++ )
 				{
-					if ( string.IsNullOrWhiteSpace( order.CouponsReference?.Url ) )
-						break;
-
 					var endpoint = ParamsBuilder.CreateGetNextPageParams( new BigCommerceCommandConfig( i, RequestMaxLimit ) );
 					var coupons = await ActionPolicies.GetAsync( marker, endpoint ).Get( async () =>
 						await this._webRequestServices.GetResponseByRelativeUrlAsync< List< BigCommerceOrderCoupon > >( order.CouponsReference.Url, endpoint, marker ) );

--- a/src/BigCommerceAccess/BigCommerceProductsServiceV2.cs
+++ b/src/BigCommerceAccess/BigCommerceProductsServiceV2.cs
@@ -26,8 +26,8 @@ namespace BigCommerceAccess
 			for( var i = 1; i < int.MaxValue; i++ )
 			{
 				var endpoint = ParamsBuilder.CreateGetNextPageParams( new BigCommerceCommandConfig( i, RequestMaxLimit ) );
-				var productsWithinPage = ActionPolicies.Get.Get( () =>
-					base._webRequestServices.GetResponse< List< BigCommerceProduct > >( BigCommerceCommand.GetProductsV2, endpoint, marker ) );
+				var productsWithinPage = ActionPolicies.Get( marker, endpoint ).Get( () =>
+					base._webRequestServices.GetResponseByRelativeUrl< List< BigCommerceProduct > >( BigCommerceCommand.GetProductsV2, endpoint, marker ) );
 				this.CreateApiDelay( productsWithinPage.Limits ).Wait(); //API requirement
 
 				if( productsWithinPage.Response == null )
@@ -56,8 +56,8 @@ namespace BigCommerceAccess
 			for( var i = 1; i < int.MaxValue; i++ )
 			{
 				var endpoint = ParamsBuilder.CreateGetNextPageParams( new BigCommerceCommandConfig( i, RequestMaxLimit ) );
-				var productsWithinPage = await ActionPolicies.GetAsync.Get( async () =>
-					await base._webRequestServices.GetResponseAsync< List< BigCommerceProduct > >( BigCommerceCommand.GetProductsV2, endpoint, marker ) );
+				var productsWithinPage = await ActionPolicies.GetAsync( marker, endpoint ).Get( async () =>
+					await base._webRequestServices.GetResponseByRelativeUrlAsync< List< BigCommerceProduct > >( BigCommerceCommand.GetProductsV2, endpoint, marker ) );
 				await this.CreateApiDelay( productsWithinPage.Limits, token ); //API requirement
 
 				if( productsWithinPage.Response == null )
@@ -80,8 +80,9 @@ namespace BigCommerceAccess
 
 		protected override void FillWeightUnit( IEnumerable< BigCommerceProduct > products, string marker )
 		{
-			var store = ActionPolicies.Get.Get( () =>
-				this._webRequestServices.GetResponse< BigCommerceStore >( BigCommerceCommand.GetStoreV2, string.Empty, marker ) );
+			var command = BigCommerceCommand.GetStoreV2;
+			var store = ActionPolicies.Get( marker, command.Command ).Get( () =>
+				this._webRequestServices.GetResponseByRelativeUrl< BigCommerceStore >( command, string.Empty, marker ) );
 			this.CreateApiDelay( store.Limits ).Wait(); //API requirement
 
 			foreach( var product in products )
@@ -92,8 +93,9 @@ namespace BigCommerceAccess
 
 		protected override async Task FillWeightUnitAsync( IEnumerable< BigCommerceProduct > products, CancellationToken token, string marker )
 		{
-			var store = await ActionPolicies.GetAsync.Get( async () =>
-				await this._webRequestServices.GetResponseAsync< BigCommerceStore >( BigCommerceCommand.GetStoreV2, string.Empty, marker ) );
+			var command = BigCommerceCommand.GetStoreV2;
+			var store = await ActionPolicies.GetAsync( marker, command.Command ).Get( async () =>
+				await this._webRequestServices.GetResponseByRelativeUrlAsync< BigCommerceStore >( command, string.Empty, marker ) );
 			await this.CreateApiDelay( store.Limits, token ); //API requirement
 
 			foreach( var product in products )
@@ -108,8 +110,8 @@ namespace BigCommerceAccess
 			for( var i = 1; i < int.MaxValue; i++ )
 			{
 				var endpoint = ParamsBuilder.CreateGetNextPageParams( new BigCommerceCommandConfig( i, RequestMaxLimit ) );
-				var brandsWithinPage = ActionPolicies.Get.Get( () =>
-					this._webRequestServices.GetResponse< List< BigCommerceBrand > >( BigCommerceCommand.GetBrandsV2, endpoint, marker ) );
+				var brandsWithinPage = ActionPolicies.Get( marker, endpoint ).Get( () =>
+					this._webRequestServices.GetResponseByRelativeUrl< List< BigCommerceBrand > >( BigCommerceCommand.GetBrandsV2, endpoint, marker ) );
 				this.CreateApiDelay( brandsWithinPage.Limits ).Wait(); //API requirement
 
 				if( brandsWithinPage.Response == null )
@@ -129,8 +131,8 @@ namespace BigCommerceAccess
 			for( var i = 1; i < int.MaxValue; i++ )
 			{
 				var endpoint = ParamsBuilder.CreateGetNextPageParams( new BigCommerceCommandConfig( i, RequestMaxLimit ) );
-				var brandsWithinPage = await ActionPolicies.GetAsync.Get( async () =>
-					await this._webRequestServices.GetResponseAsync< List< BigCommerceBrand > >( BigCommerceCommand.GetBrandsV2, endpoint, marker ) );
+				var brandsWithinPage = await ActionPolicies.GetAsync( marker, endpoint ).Get( async () =>
+					await this._webRequestServices.GetResponseByRelativeUrlAsync< List< BigCommerceBrand > >( BigCommerceCommand.GetBrandsV2, endpoint, marker ) );
 				await this.CreateApiDelay( brandsWithinPage.Limits, token ); //API requirement
 
 				if( brandsWithinPage.Response == null )
@@ -155,7 +157,7 @@ namespace BigCommerceAccess
 				var endpoint = ParamsBuilder.CreateProductUpdateEndpoint( product.Id );
 				var jsonContent = new { inventory_level = product.Quantity }.ToJson();
 
-				var limit = ActionPolicies.Submit.Get( () =>
+				var limit = ActionPolicies.Submit( marker, endpoint ).Get( () =>
 					this._webRequestServices.PutData( BigCommerceCommand.UpdateProductV2, endpoint, jsonContent, marker ) );
 				this.CreateApiDelay( limit ).Wait(); //API requirement
 			}
@@ -170,7 +172,7 @@ namespace BigCommerceAccess
 				var endpoint = ParamsBuilder.CreateProductUpdateEndpoint( product.Id );
 				var jsonContent = new { inventory_level = product.Quantity }.ToJson();
 
-				var limit = await ActionPolicies.SubmitAsync.Get( async () =>
+				var limit = await ActionPolicies.SubmitAsync( marker, endpoint ).Get( async () =>
 					await this._webRequestServices.PutDataAsync( BigCommerceCommand.UpdateProductV2, endpoint, jsonContent, marker ) );
 
 				await this.CreateApiDelay( limit, token ); //API requirement
@@ -186,7 +188,7 @@ namespace BigCommerceAccess
 				var endpoint = ParamsBuilder.CreateProductOptionUpdateEndpoint( option.ProductId, option.Id );
 				var jsonContent = new { inventory_level = option.Quantity }.ToJson();
 
-				var limit = ActionPolicies.Submit.Get( () =>
+				var limit = ActionPolicies.Submit( marker, endpoint ).Get( () =>
 					this._webRequestServices.PutData( BigCommerceCommand.UpdateProductV2, endpoint, jsonContent, marker ) );
 				this.CreateApiDelay( limit ).Wait(); //API requirement
 			}
@@ -201,7 +203,7 @@ namespace BigCommerceAccess
 				var endpoint = ParamsBuilder.CreateProductOptionUpdateEndpoint( option.ProductId, option.Id );
 				var jsonContent = new { inventory_level = option.Quantity }.ToJson();
 
-				var limit = await ActionPolicies.SubmitAsync.Get( async () =>
+				var limit = await ActionPolicies.SubmitAsync( marker, endpoint ).Get( async () =>
 					await this._webRequestServices.PutDataAsync( BigCommerceCommand.UpdateProductV2, endpoint, jsonContent, marker ) );
 				await this.CreateApiDelay( limit, token ); //API requirement
 			} );

--- a/src/BigCommerceAccess/BigCommerceProductsServiceV2OAuth.cs
+++ b/src/BigCommerceAccess/BigCommerceProductsServiceV2OAuth.cs
@@ -27,8 +27,8 @@ namespace BigCommerceAccess
 			{
 				var endpoint = ParamsBuilder.CreateGetNextPageParams( new BigCommerceCommandConfig( i, RequestMaxLimit ) );
 				endpoint += includeExtendInfo ? ParamsBuilder.GetFieldsForProductSync() : ParamsBuilder.GetFieldsForInventorySync();
-				var productsWithinPage = ActionPolicies.Get.Get( () =>
-					this._webRequestServices.GetResponse< List< BigCommerceProduct > >( BigCommerceCommand.GetProductsV2_OAuth, endpoint, marker ) );
+				var productsWithinPage = ActionPolicies.Get( marker, endpoint ).Get( () =>
+					this._webRequestServices.GetResponseByRelativeUrl< List< BigCommerceProduct > >( BigCommerceCommand.GetProductsV2_OAuth, endpoint, marker ) );
 				this.CreateApiDelay( productsWithinPage.Limits ).Wait(); //API requirement
 
 				if( productsWithinPage.Response == null )
@@ -58,8 +58,8 @@ namespace BigCommerceAccess
 			{
 				var endpoint = ParamsBuilder.CreateGetNextPageParams( new BigCommerceCommandConfig( i, RequestMaxLimit ) );
 				endpoint += includeExtendedInfo ? ParamsBuilder.GetFieldsForProductSync() : ParamsBuilder.GetFieldsForInventorySync();
-				var productsWithinPage = await ActionPolicies.GetAsync.Get( async () =>
-					await base._webRequestServices.GetResponseAsync< List< BigCommerceProduct > >( BigCommerceCommand.GetProductsV2_OAuth, endpoint, marker ) );
+				var productsWithinPage = await ActionPolicies.GetAsync( marker, endpoint ).Get( async () =>
+					await base._webRequestServices.GetResponseByRelativeUrlAsync< List< BigCommerceProduct > >( BigCommerceCommand.GetProductsV2_OAuth, endpoint, marker ) );
 				await this.CreateApiDelay( productsWithinPage.Limits, token ); //API requirement
 
 				if( productsWithinPage.Response == null )
@@ -91,7 +91,7 @@ namespace BigCommerceAccess
 				var endpoint = ParamsBuilder.CreateProductUpdateEndpoint( product.Id );
 				var jsonContent = new { inventory_level = product.Quantity }.ToJson();
 
-				var limit = ActionPolicies.Submit.Get( () =>
+				var limit = ActionPolicies.Submit( marker, endpoint ).Get( () =>
 					this._webRequestServices.PutData( BigCommerceCommand.UpdateProductV2_OAuth, endpoint, jsonContent, marker ) );
 				this.CreateApiDelay( limit ).Wait(); //API requirement
 			}
@@ -106,14 +106,14 @@ namespace BigCommerceAccess
 				var endpoint = ParamsBuilder.CreateProductUpdateEndpoint( product.Id );
 				var jsonContent = new { inventory_level = product.Quantity }.ToJson();
 
-				var limit = await ActionPolicies.SubmitAsync.Get( async () =>
+				var limit = await ActionPolicies.SubmitAsync( marker, endpoint ).Get( async () =>
 					await this._webRequestServices.PutDataAsync( BigCommerceCommand.UpdateProductV2_OAuth, endpoint, jsonContent, marker ) );
 
 				await this.CreateApiDelay( limit, token ); //API requirement
 			} );
 		}
 
-		public void UpdateProductOptions(List<BigCommerceProductOption> productOptions)
+		public void UpdateProductOptions( List<BigCommerceProductOption> productOptions )
 		{
 			var marker = this.GetMarker();
 
@@ -122,7 +122,7 @@ namespace BigCommerceAccess
 				var endpoint = ParamsBuilder.CreateProductOptionUpdateEndpoint( option.ProductId, option.Id );
 				var jsonContent = new { inventory_level = option.Quantity }.ToJson();
 
-				var limit = ActionPolicies.Submit.Get( () =>
+				var limit = ActionPolicies.Submit( marker, endpoint ).Get( () =>
 					this._webRequestServices.PutData( BigCommerceCommand.UpdateProductV2_OAuth, endpoint, jsonContent, marker ) );
 				this.CreateApiDelay( limit ).Wait(); //API requirement
 			}
@@ -137,7 +137,7 @@ namespace BigCommerceAccess
 				var endpoint = ParamsBuilder.CreateProductOptionUpdateEndpoint( option.ProductId, option.Id );
 				var jsonContent = new { inventory_level = option.Quantity }.ToJson();
 
-				var limit = await ActionPolicies.SubmitAsync.Get( async () =>
+				var limit = await ActionPolicies.SubmitAsync( marker, endpoint ).Get( async () =>
 					await this._webRequestServices.PutDataAsync( BigCommerceCommand.UpdateProductV2_OAuth, endpoint, jsonContent, marker ) );
 				await this.CreateApiDelay( limit, token ); //API requirement
 			} );

--- a/src/BigCommerceAccess/Misc/ActionPolicies.cs
+++ b/src/BigCommerceAccess/Misc/ActionPolicies.cs
@@ -12,33 +12,105 @@ namespace BigCommerceAccess.Misc
 #else
 		public const int RetryCount = 10;
 #endif
-
-		public static readonly ActionPolicy Submit = ActionPolicy.Handle< Exception >().Retry( RetryCount, ( ex, i ) =>
+		
+		public static ActionPolicy Submit( string marker, string url )
 		{
-			BigCommerceLogger.Log.Trace( ex, "Retrying BigCommerce API submit call for the {0} time", i );
-			SystemUtil.Sleep( TimeSpan.FromSeconds( 5 + 20 * i ) );
-		} );
-
-		public static readonly ActionPolicyAsync SubmitAsync = ActionPolicyAsync.Handle< Exception >().RetryAsync( RetryCount, async ( ex, i ) =>
-		{
-			BigCommerceLogger.Log.Trace( ex, "Retrying BigCommerce API submit call for the {0} time", i );
-			await Task.Delay( TimeSpan.FromSeconds( 5 + 20 * i ) );
-		} );
-
-		public static readonly ActionPolicy Get = ActionPolicy.Handle< Exception >().Retry( RetryCount, LogRetryAndWait );
-
-		public static readonly ActionPolicyAsync GetAsync = ActionPolicyAsync.Handle< Exception >().RetryAsync( RetryCount, LogRetryAndWaitAsync );
-
-		public static void LogRetryAndWait( Exception ex, int retryAttempt )
-		{
-			BigCommerceLogger.Log.Trace( ex, "Retrying BigCommerce API get call for the {0} time", retryAttempt );
-			SystemUtil.Sleep( TimeSpan.FromSeconds( 5 + 20 * retryAttempt ) );
+			return ActionPolicy.Handle< Exception >().Retry( RetryCount, ( ex, i ) =>
+			{
+				var delay = TimeSpan.FromSeconds( 5 + 20 * i );
+				BigCommerceLogger.LogTraceException( new RetryInfo()
+				{
+					Mark = marker,
+					Url = url,
+					CurrentRetryAttempt = i,
+					TotalRetriesAttempts = RetryCount,
+					DelayInSeconds = delay.TotalSeconds,
+					Category = MessageCategoryEnum.Warning
+				}, ex );
+				SystemUtil.Sleep( delay );
+			} );
 		}
 
-		public static async Task LogRetryAndWaitAsync( Exception ex, int retryAttempt )
+		public static ActionPolicyAsync SubmitAsync( string marker, string url )
 		{
-			BigCommerceLogger.Log.Trace( ex, "Retrying BigCommerce API get call for the {0} time", retryAttempt );
-			await Task.Delay( TimeSpan.FromSeconds( 5 + 20 * retryAttempt ) );
+			return ActionPolicyAsync.Handle< Exception >().RetryAsync( RetryCount, async ( ex, i ) =>
+			{
+				var delay = TimeSpan.FromSeconds( 5 + 20 * i );
+				BigCommerceLogger.LogTraceException( new RetryInfo()
+				{
+					Mark = marker,
+					Url = url,
+					CurrentRetryAttempt = i,
+					TotalRetriesAttempts = RetryCount,
+					DelayInSeconds = delay.TotalSeconds,
+					Category = MessageCategoryEnum.Warning
+				}, ex );
+				await Task.Delay( delay );
+			} );
+		}
+
+		public static ActionPolicy Get( string marker, string url )
+		{
+			return ActionPolicy.Handle< Exception >().Retry( RetryCount, ( ex, retryAttempt ) => { 
+				var delay = TimeSpan.FromSeconds( 5 + 20 * retryAttempt );
+				BigCommerceLogger.LogTraceException( new RetryInfo()
+				{
+					Mark = marker,
+					Url = url,
+					CurrentRetryAttempt = retryAttempt,
+					TotalRetriesAttempts = RetryCount,
+					DelayInSeconds = delay.TotalSeconds,
+					Category = MessageCategoryEnum.Warning
+				}, ex );
+				SystemUtil.Sleep( delay );
+			} );
+		}
+
+		public static ActionPolicyAsync GetAsync( string marker, string url )
+		{
+			return ActionPolicyAsync.Handle< Exception >().RetryAsync( RetryCount, async ( ex, retryAttempt ) => { 
+				var delay = TimeSpan.FromSeconds( 5 + 20 * retryAttempt );
+				BigCommerceLogger.LogTraceException( new RetryInfo()
+				{
+					Mark = marker,
+					Url = url,
+					CurrentRetryAttempt = retryAttempt,
+					TotalRetriesAttempts = RetryCount,
+					DelayInSeconds = delay.TotalSeconds,
+					Category = MessageCategoryEnum.Warning
+				}, ex );
+				await Task.Delay( delay );
+			} );
+		}
+
+		public static void LogRetryAndWait( Exception ex, string marker, string url, int retryAttempt )
+		{
+			var delay = TimeSpan.FromSeconds( 5 + 20 * retryAttempt );
+			BigCommerceLogger.LogTraceException( new RetryInfo()
+			{
+				Mark = marker,
+				Url = url,
+				CurrentRetryAttempt = retryAttempt,
+				TotalRetriesAttempts = RetryCount,
+				DelayInSeconds = delay.TotalSeconds,
+				Category = MessageCategoryEnum.Warning
+			}, ex );
+			SystemUtil.Sleep( delay );
+		}
+
+		public static async Task LogRetryAndWaitAsync( Exception ex, string marker, string url, int retryAttempt )
+		{
+			var delay = TimeSpan.FromSeconds( 5 + 20 * retryAttempt );
+			BigCommerceLogger.LogTraceException( new RetryInfo()
+			{
+				Mark = marker,
+				Url = url,
+				CurrentRetryAttempt = retryAttempt,
+				TotalRetriesAttempts = RetryCount,
+				DelayInSeconds = delay.TotalSeconds,
+				Category = MessageCategoryEnum.Warning
+			}, ex );
+			await Task.Delay( delay );
 		}
 	}
 }

--- a/src/BigCommerceAccess/Misc/BigCommerceLogger.cs
+++ b/src/BigCommerceAccess/Misc/BigCommerceLogger.cs
@@ -25,7 +25,8 @@ namespace BigCommerceAccess.Misc
 
 		public static void LogTraceException( CallInfo callInfo, Exception exception )
 		{
-			if ( callInfo is ResponseInfo responseInfo )
+			var responseInfo = callInfo as ResponseInfo;
+			if ( responseInfo != null )
 			{
 				Log().Trace( exception, "[{channel}] [{version}] [{tenantId}] [{accountId}] [{callCategory}] [{callLibMethodName}] Request '{callMarker}' to url '{callUrl}' failed. Response status code: {callResponseStatusCode}", 
 					ChannelName, 
@@ -39,7 +40,8 @@ namespace BigCommerceAccess.Misc
 					responseInfo.StatusCode );
 			}
 
-			if ( callInfo is RetryInfo retryInfo )
+			var retryInfo = callInfo as RetryInfo;
+			if ( retryInfo != null )
 			{
 				Log().Trace( exception, "[{channel}] [{version}] [{tenantId}] [{accountId}] [{callCategory}] [{callLibMethodName}] Request '{callMarker}' to url '{callUrl}' failed. Gonna retry request for the {callRetryAttempt} attempt, delay {callRetryDelay} seconds, total retry attempts {callRetryTotalAttempts}", 
 					ChannelName, 

--- a/src/BigCommerceAccess/Misc/BigCommerceLogger.cs
+++ b/src/BigCommerceAccess/Misc/BigCommerceLogger.cs
@@ -23,94 +23,81 @@ namespace BigCommerceAccess.Misc
 			return NetcoLogger.GetLogger( "BigCommerceLogger" );
 		}
 
-		public static void LogTraceException( CallInfo callInfo, Exception exception )
+		public static void LogTraceException( ResponseInfo responseInfo, Exception exception )
 		{
-			var responseInfo = callInfo as ResponseInfo;
-			if ( responseInfo != null )
-			{
-				Log().Trace( exception, "[{channel}] [{version}] [{tenantId}] [{accountId}] [{callCategory}] [{callLibMethodName}] Request '{callMarker}' to url '{callUrl}' failed. Response status code: {callResponseStatusCode}", 
-					ChannelName, 
-					_versionInfo, 
-					callInfo.TenantId ?? 0,
-					callInfo.ChannelAccountId ?? 0,
-					responseInfo.Category, 
-					responseInfo.LibMethodName,
-					responseInfo.Mark, 
-					responseInfo.Url, 
-					responseInfo.StatusCode );
-			}
-
-			var retryInfo = callInfo as RetryInfo;
-			if ( retryInfo != null )
-			{
-				Log().Trace( exception, "[{channel}] [{version}] [{tenantId}] [{accountId}] [{callCategory}] [{callLibMethodName}] Request '{callMarker}' to url '{callUrl}' failed. Gonna retry request for the {callRetryAttempt} attempt, delay {callRetryDelay} seconds, total retry attempts {callRetryTotalAttempts}", 
-					ChannelName, 
-					_versionInfo, 
-					callInfo.TenantId ?? 0,
-					callInfo.ChannelAccountId ?? 0,
-					retryInfo.Category, 
-					retryInfo.LibMethodName,
-					retryInfo.Mark, 
-					retryInfo.Url, 
-					retryInfo.CurrentRetryAttempt, 
-					retryInfo.DelayInSeconds, 
-					retryInfo.TotalRetriesAttempts );
-			}
+			Log().Trace( exception, "[{channel}] [{version}] [{tenantId}] [{accountId}] [{callCategory}] [{callLibMethodName}] Request '{callMarker}' to url '{callUrl}' failed. Response status code: {callResponseStatusCode}", 
+									ChannelName, 
+									_versionInfo, 
+									responseInfo.TenantId ?? 0,
+									responseInfo.ChannelAccountId ?? 0,
+									responseInfo.Category, 
+									responseInfo.LibMethodName,
+									responseInfo.Mark, 
+									responseInfo.Url, 
+									responseInfo.StatusCode );
 		}
 
-		public static void TraceLog( CallInfo callInfo )
+		public static void LogTraceException( RetryInfo retryInfo, Exception exception )
 		{
-			var requestInfo = callInfo as RequestInfo;
-			if ( requestInfo != null )
+			Log().Trace( exception, "[{channel}] [{version}] [{tenantId}] [{accountId}] [{callCategory}] [{callLibMethodName}] Request '{callMarker}' to url '{callUrl}' failed. Gonna retry request for the {callRetryAttempt} attempt, delay {callRetryDelay} seconds, total retry attempts {callRetryTotalAttempts}", 
+									ChannelName, 
+									_versionInfo, 
+									retryInfo.TenantId ?? 0,
+									retryInfo.ChannelAccountId ?? 0,
+									retryInfo.Category, 
+									retryInfo.LibMethodName,
+									retryInfo.Mark, 
+									retryInfo.Url, 
+									retryInfo.CurrentRetryAttempt, 
+									retryInfo.DelayInSeconds, 
+									retryInfo.TotalRetriesAttempts );
+		}
+
+		public static void TraceLog( RequestInfo requestInfo )
+		{
+			if ( !string.IsNullOrWhiteSpace( requestInfo.Body?.ToString() ) )
 			{
-				if ( !string.IsNullOrWhiteSpace( requestInfo.Body?.ToString() ) )
-				{
-					Log().Trace( "[{channel}] [{version}] [{tenantId}] [{accountId}] [{callCategory}] [{callLibMethodName}] Starting {callHttpMethod} call '{callMarker}' to '{callUrl}' with body: '{callRequestBody}'", 
-						ChannelName, 
-						_versionInfo, 
-						callInfo.TenantId ?? 0,
-						callInfo.ChannelAccountId ?? 0,
-						requestInfo.Category, 
-						requestInfo.LibMethodName, 
-						requestInfo.HttpMethod.ToString().ToUpper(), 
-						requestInfo.Mark, 
-						requestInfo.Url, 
-						requestInfo.Body ?? string.Empty );
-				}
-				else
-				{
-					Log().Trace( "[{channel}] [{version}] [{tenantId}] [{accountId}] [{callCategory}] [{callLibMethodName}] Starting {callHttpMethod} call '{callMarker}' to '{callUrl}'", 
-						ChannelName, 
-						_versionInfo, 
-						callInfo.TenantId ?? 0,
-						callInfo.ChannelAccountId ?? 0,
-						requestInfo.Category, 
-						requestInfo.LibMethodName, 
-						requestInfo.HttpMethod.ToString().ToUpper(),
-						requestInfo.Mark,  
-						requestInfo.Url );
-				}
-				
+				Log().Trace( "[{channel}] [{version}] [{tenantId}] [{accountId}] [{callCategory}] [{callLibMethodName}] Starting {callHttpMethod} call '{callMarker}' to '{callUrl}' with body: '{callRequestBody}'", 
+								ChannelName, 
+								_versionInfo, 
+								requestInfo.TenantId ?? 0,
+								requestInfo.ChannelAccountId ?? 0,
+								requestInfo.Category, 
+								requestInfo.LibMethodName, 
+								requestInfo.HttpMethod.ToString().ToUpper(), 
+								requestInfo.Mark, 
+								requestInfo.Url, 
+								requestInfo.Body ?? string.Empty );
 				return;
 			}
 			
-			var responseInfo = callInfo as ResponseInfo;
-			if ( responseInfo != null )
-			{
-				Log().Trace( "[{channel}] [{version}] [{tenantId}] [{accountId}] [{callCategory}] [{callLibMethodName}] Completed call '{callMarker}' to '{callUrl}'. Response status code: {callResponseStatusCode}, api calls remaining: {callRemainingCalls}, system version: {callExternalSystemVersion}. Response body: '{callResponseBody}'", 
-					ChannelName,
-					_versionInfo, 
-					callInfo.TenantId ?? 0,
-					callInfo.ChannelAccountId ?? 0,
-					responseInfo.Category,
-					callInfo.LibMethodName,
-					callInfo.Mark, 
-					callInfo.Url, 
-					responseInfo.StatusCode, 
-					responseInfo.RemainingCalls, 
-					responseInfo.SystemVersion, 
-					responseInfo.Response != null ? responseInfo.Response.ToJson() : string.Empty );
-			}
+			Log().Trace( "[{channel}] [{version}] [{tenantId}] [{accountId}] [{callCategory}] [{callLibMethodName}] Starting {callHttpMethod} call '{callMarker}' to '{callUrl}'", 
+							ChannelName, 
+							_versionInfo, 
+							requestInfo.TenantId ?? 0,
+							requestInfo.ChannelAccountId ?? 0,
+							requestInfo.Category, 
+							requestInfo.LibMethodName, 
+							requestInfo.HttpMethod.ToString().ToUpper(),
+							requestInfo.Mark,  
+							requestInfo.Url );
+		}
+
+		public static void TraceLog( ResponseInfo responseInfo )
+		{
+			Log().Trace( "[{channel}] [{version}] [{tenantId}] [{accountId}] [{callCategory}] [{callLibMethodName}] Completed call '{callMarker}' to '{callUrl}'. Response status code: {callResponseStatusCode}, api calls remaining: {callRemainingCalls}, system version: {callExternalSystemVersion}. Response body: '{callResponseBody}'", 
+							ChannelName,
+							_versionInfo, 
+							responseInfo.TenantId ?? 0,
+							responseInfo.ChannelAccountId ?? 0,
+							responseInfo.Category,
+							responseInfo.LibMethodName,
+							responseInfo.Mark, 
+							responseInfo.Url, 
+							responseInfo.StatusCode, 
+							responseInfo.RemainingCalls, 
+							responseInfo.SystemVersion, 
+							responseInfo.Response != null ? responseInfo.Response.ToJson() : string.Empty );
 		}
 	}
 }

--- a/src/BigCommerceAccess/Misc/BigCommerceLogger.cs
+++ b/src/BigCommerceAccess/Misc/BigCommerceLogger.cs
@@ -1,14 +1,114 @@
-﻿using Netco.Logging;
+﻿using System;
+using System.Diagnostics;
+using System.Reflection;
+using Netco.Logging;
+using ServiceStack;
 
 namespace BigCommerceAccess.Misc
 {
 	public class BigCommerceLogger
 	{
-		public static ILogger Log{ get; private set; }
+		private static readonly string _versionInfo;
+		private const string ChannelName = "bigCommerce";
+		private const int MaxLogLineSize = 0xA00000; //10mb
 
 		static BigCommerceLogger()
 		{
-			Log = NetcoLogger.GetLogger( "BigCommerceLogger" );
+			Assembly assembly = Assembly.GetExecutingAssembly();
+			_versionInfo = FileVersionInfo.GetVersionInfo( assembly.Location ).FileVersion;
+		}
+
+		public static ILogger Log()
+		{
+			return NetcoLogger.GetLogger( "BigCommerceLogger" );
+		}
+
+		public static void LogTraceException( CallInfo callInfo, Exception exception )
+		{
+			if ( callInfo is ResponseInfo responseInfo )
+			{
+				Log().Trace( exception, "[{channel}] [{version}] [{tenantId}] [{accountId}] [{callCategory}] [{callLibMethodName}] Request '{callMarker}' to url '{callUrl}' failed. Response status code: {callResponseStatusCode}", 
+					ChannelName, 
+					_versionInfo, 
+					callInfo.TenantId ?? 0,
+					callInfo.ChannelAccountId ?? 0,
+					responseInfo.Category, 
+					responseInfo.LibMethodName,
+					responseInfo.Mark, 
+					responseInfo.Url, 
+					responseInfo.StatusCode );
+			}
+
+			if ( callInfo is RetryInfo retryInfo )
+			{
+				Log().Trace( exception, "[{channel}] [{version}] [{tenantId}] [{accountId}] [{callCategory}] [{callLibMethodName}] Request '{callMarker}' to url '{callUrl}' failed. Gonna retry request for the {callRetryAttempt} attempt, delay {callRetryDelay} seconds, total retry attempts {callRetryTotalAttempts}", 
+					ChannelName, 
+					_versionInfo, 
+					callInfo.TenantId ?? 0,
+					callInfo.ChannelAccountId ?? 0,
+					retryInfo.Category, 
+					retryInfo.LibMethodName,
+					retryInfo.Mark, 
+					retryInfo.Url, 
+					retryInfo.CurrentRetryAttempt, 
+					retryInfo.DelayInSeconds, 
+					retryInfo.TotalRetriesAttempts );
+			}
+		}
+
+		public static void TraceLog( CallInfo callInfo )
+		{
+			var requestInfo = callInfo as RequestInfo;
+			if ( requestInfo != null )
+			{
+				if ( !string.IsNullOrWhiteSpace( requestInfo.Body?.ToString() ) )
+				{
+					Log().Trace( "[{channel}] [{version}] [{tenantId}] [{accountId}] [{callCategory}] [{callLibMethodName}] Starting {callHttpMethod} call '{callMarker}' to '{callUrl}' with body: '{callRequestBody}'", 
+						ChannelName, 
+						_versionInfo, 
+						callInfo.TenantId ?? 0,
+						callInfo.ChannelAccountId ?? 0,
+						requestInfo.Category, 
+						requestInfo.LibMethodName, 
+						requestInfo.HttpMethod.ToString().ToUpper(), 
+						requestInfo.Mark, 
+						requestInfo.Url, 
+						requestInfo.Body ?? string.Empty );
+				}
+				else
+				{
+					Log().Trace( "[{channel}] [{version}] [{tenantId}] [{accountId}] [{callCategory}] [{callLibMethodName}] Starting {callHttpMethod} call '{callMarker}' to '{callUrl}'", 
+						ChannelName, 
+						_versionInfo, 
+						callInfo.TenantId ?? 0,
+						callInfo.ChannelAccountId ?? 0,
+						requestInfo.Category, 
+						requestInfo.LibMethodName, 
+						requestInfo.HttpMethod.ToString().ToUpper(),
+						requestInfo.Mark,  
+						requestInfo.Url );
+				}
+				
+				return;
+			}
+			
+			var responseInfo = callInfo as ResponseInfo;
+			if ( responseInfo != null )
+			{
+				Log().Trace( "[{channel}] [{version}] [{tenantId}] [{accountId}] [{callCategory}] [{callLibMethodName}] Completed call '{callMarker}' to '{callUrl}'. Response status code: {callResponseStatusCode}, api calls remaining: {callRemainingCalls}, system version: {callExternalSystemVersion}. Response body: '{callResponseBody}'", 
+					ChannelName,
+					_versionInfo, 
+					callInfo.TenantId ?? 0,
+					callInfo.ChannelAccountId ?? 0,
+					responseInfo.Category,
+					callInfo.LibMethodName,
+					callInfo.Mark, 
+					callInfo.Url, 
+					responseInfo.StatusCode, 
+					responseInfo.RemainingCalls, 
+					responseInfo.SystemVersion, 
+					responseInfo.Response != null ? responseInfo.Response.ToJson() : string.Empty );
+			}
 		}
 	}
 }

--- a/src/BigCommerceAccess/Misc/CallInfo.cs
+++ b/src/BigCommerceAccess/Misc/CallInfo.cs
@@ -1,0 +1,42 @@
+﻿namespace BigCommerceAccess.Misc
+{
+	public enum HttpMethodEnum { Get, Post, Put }
+	public enum MessageCategoryEnum { Information, Warning, Critical }
+
+	public abstract class CallInfo
+	{
+		protected CallInfo()
+		{
+			this.Mark = "Unknown";
+		}
+
+		public string Mark { get; set; }
+		public string LibMethodName { get; set; }
+		public string Url { get; set; }
+		public MessageCategoryEnum Category { get; set; }
+
+		public long? TenantId { get; set; }
+		public long? ChannelAccountId { get; set; }
+	}
+
+	public sealed class RequestInfo : CallInfo
+	{
+		public HttpMethodEnum HttpMethod { get; set; }
+		public object Body { get; set; }
+	}
+
+	public sealed class ResponseInfo : CallInfo
+	{
+		public object Response { get; set; }
+		public string RemainingCalls { get; set; }
+		public string SystemVersion { get; set; }
+		public string StatusCode { get; set; }
+	}
+
+	public sealed class RetryInfo : CallInfo
+	{
+		public int TotalRetriesAttempts { get; set; }
+		public int CurrentRetryAttempt { get; set; }
+		public double DelayInSeconds { get; set; }
+	}
+}

--- a/src/BigCommerceAccess/Models/Configuration/BigCommerceConfig.cs
+++ b/src/BigCommerceAccess/Models/Configuration/BigCommerceConfig.cs
@@ -16,6 +16,9 @@ namespace BigCommerceAccess.Models.Configuration
 		public string ClientSecret{ get; private set; }
 		public string Token{ get; private set; }
 
+		public long? TenantId { get; set; }
+		public long? ChannelAccountId { get; set; }
+
 		public BigCommerceConfig( string shopName, string userName, string apiKey )
 		{
 			Condition.Requires( shopName, "shopName" ).IsNotNullOrWhiteSpace();

--- a/src/BigCommerceAccess/Services/WebRequestServices.cs
+++ b/src/BigCommerceAccess/Services/WebRequestServices.cs
@@ -1,9 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Net;
 using System.Net.Security;
+using System.Runtime.CompilerServices;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading;
@@ -12,10 +11,8 @@ using BigCommerceAccess.Misc;
 using BigCommerceAccess.Models;
 using BigCommerceAccess.Models.Command;
 using BigCommerceAccess.Models.Configuration;
-using BigCommerceAccess.Models.Order;
 using BigCommerceAccess.Models.Throttling;
 using Newtonsoft.Json;
-using ServiceStack;
 
 namespace BigCommerceAccess.Services
 {
@@ -43,55 +40,61 @@ namespace BigCommerceAccess.Services
 			return ( HttpWebRequest )WebRequest.Create( uri );
 		}
 
-		public BigCommerceResponse< T > GetResponse< T >( string url, string commandParams, string marker ) where T : class
+		public BigCommerceResponse< T > GetResponseByRelativeUrl< T >( string url, string commandParams, string marker, [ CallerMemberName ] string callerMethodName = null ) where T : class
 		{
 			var requestUrl = this.GetUrl( url, commandParams );
-			var result = this.GetResponse< T >( requestUrl, marker );
+			var result = this.GetResponse< T >( requestUrl, marker, callerMethodName );
 			return result;
 		}
 
-		public async Task< BigCommerceResponse< T > > GetResponseAsync< T >( string url, string commandParams, string marker ) where T : class
+		public async Task< BigCommerceResponse< T > > GetResponseByRelativeUrlAsync< T >( string url, string commandParams, string marker, [ CallerMemberName ] string callerMethodName = null ) where T : class
 		{
 			var requestUrl = this.GetUrl( url, commandParams );
-			var result = await this.GetResponseAsync< T >( requestUrl, marker );
+			var result = await this.GetResponseAsync< T >( requestUrl, marker, callerMethodName );
 			return result;
 		}
 
-		public BigCommerceResponse< T > GetResponse< T >( BigCommerceCommand command, string commandParams, string marker ) where T : class
+		public BigCommerceResponse< T > GetResponseByRelativeUrl< T >( BigCommerceCommand command, string commandParams, string marker, [ CallerMemberName ] string callerMethodName = null ) where T : class
 		{
 			var requestUrl = this.GetUrl( command, commandParams );
-			var result = this.GetResponse< T >( requestUrl, marker );
+			var result = this.GetResponse< T >( requestUrl, marker, callerMethodName );
 			return result;
 		}
 
-		public async Task< BigCommerceResponse< T > > GetResponseAsync< T >( BigCommerceCommand command, string commandParams, string marker ) where T : class
+		public async Task< BigCommerceResponse< T > > GetResponseByRelativeUrlAsync< T >( BigCommerceCommand command, string commandParams, string marker, [ CallerMemberName ] string callerMethodName = null ) where T : class
 		{
 			var requestUrl = this.GetUrl( command, commandParams );
-			var result = await this.GetResponseAsync< T >( requestUrl, marker );
+			var result = await this.GetResponseAsync< T >( requestUrl, marker, callerMethodName );
 			return result;
 		}
 
-		public BigCommerceResponse< T > GetResponse< T >( string url, string marker ) where T : class
+		public BigCommerceResponse< T > GetResponse< T >( string url, string marker, [ CallerMemberName ] string callerMethodName = null ) where T : class
 		{
-			this.LogGetInfo( url, marker );
+			this.LogCallStarted( url, marker, callerMethodName );
+			var responseStatusCode = HttpStatusCode.OK;
 
 			try
 			{
 				BigCommerceResponse< T > result;
 				var request = this.CreateGetServiceGetRequest( url );
 				using( var response = request.GetResponse() )
-					result = this.ParseResponse< T >( response, marker );
+				{
+					responseStatusCode = ( ( HttpWebResponse )response ).StatusCode;
+					result = this.ParseResponse< T >( response, marker, url, callerMethodName );
+				}
+					
 				return result;
 			}
 			catch( Exception ex )
 			{
-				throw this.ExceptionForGetInfo( url, ex, marker );
+				throw this.HandleExceptionAndLog( url, marker, callerMethodName, responseStatusCode.ToString(), ex );
 			}
 		}
 
-		public async Task< BigCommerceResponse< T > > GetResponseAsync< T >( string url, string marker ) where T : class
+		public async Task< BigCommerceResponse< T > > GetResponseAsync< T >( string url, string marker, [ CallerMemberName ] string callerMethodName = null ) where T : class
 		{
-			this.LogGetInfo( url, marker );
+			this.LogCallStarted( url, marker, callerMethodName );
+			var responseStatusCode = HttpStatusCode.OK;
 
 			try
 			{
@@ -101,41 +104,46 @@ namespace BigCommerceAccess.Services
 				using( timeoutToken.Register( request.Abort ) )
 				using( var response = await request.GetResponseAsync() )
 				{
+					responseStatusCode = ( ( HttpWebResponse )response ).StatusCode;
 					timeoutToken.ThrowIfCancellationRequested();
-					result = this.ParseResponse< T >( response, marker );
+					result = this.ParseResponse< T >( response, marker, url, callerMethodName );
 				}
 				return result;
 			}
 			catch( Exception ex )
 			{
-				throw this.ExceptionForGetInfo( url, ex, marker );
+				throw this.HandleExceptionAndLog( url, marker, callerMethodName, responseStatusCode.ToString(), ex );
 			}
 		}
 
-		public IBigCommerceRateLimits PutData( BigCommerceCommand command, string endpoint, string jsonContent, string marker )
+		public IBigCommerceRateLimits PutData( BigCommerceCommand command, string endpoint, string jsonContent, string marker, [ CallerMemberName ] string callerMethodName = null )
 		{
 			var url = this.GetUrl( command, endpoint );
-			this.LogPutInfo( url, jsonContent, marker );
+			this.LogCallStarted( url, marker, callerMethodName, HttpMethodEnum.Put, jsonContent );
+			var responseStatusCode = HttpStatusCode.OK;
 
 			try
 			{
 				var request = this.CreateServicePutRequest( url, jsonContent );
 				using( var response = ( HttpWebResponse )request.GetResponse() )
 				{
-					this.LogPutInfoResult( url, response.StatusCode, jsonContent, marker );
-					return this.ParseLimits( response );
+					responseStatusCode = response.StatusCode;
+					var currentLimits = this.ParseLimits( response );
+					this.LogCallEnded( url, marker, callerMethodName, response.StatusCode.ToString(), null, currentLimits.CallsRemaining.ToString(), null );
+					return currentLimits;
 				}
 			}
 			catch( Exception ex )
 			{
-				throw this.ExceptionForPutInfo( url, ex, marker );
+				throw this.HandleExceptionAndLog( url, marker, callerMethodName, responseStatusCode.ToString(), ex );
 			}
 		}
 
-		public async Task< IBigCommerceRateLimits > PutDataAsync( BigCommerceCommand command, string endpoint, string jsonContent, string marker )
+		public async Task< IBigCommerceRateLimits > PutDataAsync( BigCommerceCommand command, string endpoint, string jsonContent, string marker, [ CallerMemberName ] string callerMethodName = null )
 		{
 			var url = this.GetUrl( command, endpoint );
-			this.LogPutInfo( url, jsonContent, marker );
+			this.LogCallStarted( url, marker, callerMethodName, HttpMethodEnum.Put, jsonContent );
+			var responseStatusCode = HttpStatusCode.OK;
 
 			try
 			{
@@ -144,14 +152,16 @@ namespace BigCommerceAccess.Services
 				using( timeoutToken.Register( request.Abort ) )
 				using( var response = await request.GetResponseAsync() )
 				{
+					responseStatusCode = ( ( HttpWebResponse )response ).StatusCode;
 					timeoutToken.ThrowIfCancellationRequested();
-					this.LogPutInfoResult( url, ( ( HttpWebResponse )response ).StatusCode, jsonContent, marker );
-					return this.ParseLimits( response );
+					var currentLimits = this.ParseLimits( response );
+					this.LogCallEnded( url, marker, callerMethodName, ( ( HttpWebResponse )response ).StatusCode.ToString(), null, currentLimits.CallsRemaining.ToString(), null );
+					return currentLimits;
 				}
 			}
 			catch( Exception ex )
 			{
-				throw this.ExceptionForPutInfo( url, ex, marker );
+				throw this.HandleExceptionAndLog( url, marker, callerMethodName, responseStatusCode.ToString(), ex );
 			}
 		}
 
@@ -232,7 +242,7 @@ namespace BigCommerceAccess.Services
 		#endregion
 
 		#region Misc
-		private BigCommerceResponse< T > ParseResponse< T >( WebResponse response, string marker ) where T : class
+		private BigCommerceResponse< T > ParseResponse< T >( WebResponse response, string marker, string url, string callerMethodName ) where T : class
 		{
 			using( var stream = response.GetResponseStream() )
 			using( var reader = new StreamReader( stream ) )
@@ -241,35 +251,15 @@ namespace BigCommerceAccess.Services
 
 				var remainingLimit = this.GetRemainingLimit( response );
 				var version = response.Headers.Get( "X-BC-Store-Version" );
-				this.LogGetInfoResult( response.ResponseUri.OriginalString, ( ( HttpWebResponse )response ).StatusCode, jsonResponse, remainingLimit, version, marker );
+				var statusCode = ( ( HttpWebResponse )response ).StatusCode;
+				this.LogCallEnded( url, marker, callerMethodName, statusCode.ToString(), jsonResponse, remainingLimit, version );
 				var limits = this.ParseLimits( response );
 
 				if( string.IsNullOrEmpty( jsonResponse ) )
 					return new BigCommerceResponse< T >( null, limits );
 
-				var serviceStackResult = jsonResponse.FromJson< T >();
-				var jsonNetResult = JsonConvert.DeserializeObject< T >( jsonResponse );
-
-				//TODO: Added for investigation SI-730. Remove it if all are ok
-				var orders = serviceStackResult as List< BigCommerceOrder >;
-				if( orders != null && orders.Count > 0 )
-				{
-					var serviceStackOrdersStr = string.Join( ", ", orders.Select( x => string.Format( "id:{0} date:{1}", x.Id, x.DateCreated ) ) );
-					BigCommerceLogger.Log.Trace( "Marker: '{0}'. Url: '{1}' Retrieved ServiceStack BigCommerce orders: '{2}'",
-						marker, response.ResponseUri.OriginalString, serviceStackOrdersStr );
-
-					var jsonNetOrders = jsonNetResult as List< BigCommerceOrder >;
-					if( jsonNetOrders != null && jsonNetOrders.Count > 0 )
-					{
-						var jsonNetOrdersStr = string.Join( ", ", orders.Select( x => string.Format( "id:{0} date:{1}", x.Id, x.DateCreated ) ) );
-						if( !serviceStackOrdersStr.Equals( jsonNetOrdersStr ) )
-						{
-							BigCommerceLogger.Log.Warn( "Marker: '{0}'. Url: '{1}' Retrieved different Json.Net BigCommerce orders: '{2}'",
-								marker, response.ResponseUri.OriginalString, jsonNetOrdersStr );
-						}
-					}
-				}
-				return new BigCommerceResponse< T >( jsonNetResult, limits );
+				var result = JsonConvert.DeserializeObject< T >( jsonResponse );
+				return new BigCommerceResponse< T >( result, limits );
 			}
 		}
 
@@ -316,12 +306,12 @@ namespace BigCommerceAccess.Services
 			return string.Concat( "Basic ", authInfo );
 		}
 
-		private string ResolveHost( BigCommerceConfig config, string marker )
+		private string ResolveHost( BigCommerceConfig config, string marker, [ CallerMemberName ] string callerMethodName = null )
 		{
 			try
 			{
 				var url = string.Concat( config.NativeHost, BigCommerceCommand.GetOrdersCountV2.Command );
-				this.GetResponse< BigCommerceItemsCount >( url, marker );
+				this.GetResponse< BigCommerceItemsCount >( url, marker, callerMethodName );
 				return config.NativeHost;
 			}
 			catch( Exception )
@@ -329,14 +319,14 @@ namespace BigCommerceAccess.Services
 				try
 				{
 					var url = string.Concat( config.CustomHost, BigCommerceCommand.GetOrdersCountV2.Command );
-					this.GetResponse< BigCommerceItemsCount >( url, marker );
+					this.GetResponse< BigCommerceItemsCount >( url, marker, callerMethodName );
 					return config.CustomHost;
 				}
 				catch( Exception )
 				{
 					var clippedHost = config.CustomHost.Replace( "www.", string.Empty );
 					var url = string.Concat( clippedHost, BigCommerceCommand.GetOrdersCountV2.Command );
-					this.GetResponse< BigCommerceItemsCount >( url, marker );
+					this.GetResponse< BigCommerceItemsCount >( url, marker, callerMethodName );
 					return clippedHost;
 				}
 			}
@@ -349,35 +339,52 @@ namespace BigCommerceAccess.Services
 			return cancellationTokenSource.Token;
 		}
 
-		private void LogGetInfo( string url, string marker )
+		private void LogCallStarted( string url, string marker, string callerMethodName, HttpMethodEnum httpMethod = HttpMethodEnum.Get, string body = null )
 		{
-			BigCommerceLogger.Log.Trace( "Marker: '{0}'. GET call for url '{1}'", marker, url );
+			BigCommerceLogger.TraceLog( new RequestInfo()
+			{
+				Mark = marker,
+				Url = url,
+				LibMethodName = callerMethodName,
+				Category = MessageCategoryEnum.Information,
+				HttpMethod = httpMethod,
+				Body = body,
+				TenantId = this._config.TenantId,
+				ChannelAccountId = this._config.ChannelAccountId
+			} );
 		}
 
-		private void LogGetInfoResult( string url, HttpStatusCode statusCode, string jsonContent, string remainingLimit, string version, string marker )
+		private void LogCallEnded( string url, string marker, string callerMethodName, string statusCode, string response, string remainingCalls, string systemVersion )
 		{
-			BigCommerceLogger.Log.Trace( "Marker: '{0}'. GET call for url '{1}' has been completed with code '{2}'. Remaining Limit: '{3}' Version: '{4}'.\n{5}",
-				marker, url, statusCode, remainingLimit, version, jsonContent );
+			BigCommerceLogger.TraceLog( new ResponseInfo()
+			{
+				Mark = marker,
+				Url = url,
+				LibMethodName = callerMethodName,
+				Category = MessageCategoryEnum.Information,
+				Response = response,
+				StatusCode = statusCode,
+				RemainingCalls = remainingCalls,
+				SystemVersion = systemVersion,
+				TenantId = this._config.TenantId,
+				ChannelAccountId = this._config.ChannelAccountId
+			} );
 		}
 
-		private Exception ExceptionForGetInfo( string url, Exception ex, string marker )
+		private Exception HandleExceptionAndLog( string url, string marker, string callerMethodName, string statusCode, Exception ex )
 		{
-			return new Exception( string.Format( "Marker: '{0}'. GET call for url '{1}' failed", marker, url ), ex );
-		}
+			BigCommerceLogger.LogTraceException( new ResponseInfo()
+			{
+				Mark = marker,
+				Url = url,
+				LibMethodName = callerMethodName,
+				StatusCode = statusCode,
+				Category = MessageCategoryEnum.Critical,
+				TenantId = this._config.TenantId,
+				ChannelAccountId = this._config.ChannelAccountId
+			}, ex );
 
-		private void LogPutInfo( string url, string jsonContent, string marker )
-		{
-			BigCommerceLogger.Log.Trace( "Marker: '{0}'. PUT/POST data for url '{1}':\n{2}", marker, url, jsonContent );
-		}
-
-		private void LogPutInfoResult( string url, HttpStatusCode statusCode, string jsonContent, string marker )
-		{
-			BigCommerceLogger.Log.Trace( "Marker: '{0}'. PUT/POST data for url '{1}' has been completed with code '{2}'.\n{3}", marker, url, statusCode, jsonContent );
-		}
-
-		private Exception ExceptionForPutInfo( string url, Exception ex, string marker )
-		{
-			return new Exception( string.Format( "Marker: '{0}'. PUT/POST data for url '{1}' failed", marker, url ), ex );
+			return new Exception( string.Format( "Marker: '{0}'. Call to url '{1}' failed", marker, url ), ex );
 		}
 		#endregion
 

--- a/src/BigCommerceAccess/packages.config
+++ b/src/BigCommerceAccess/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CuttingEdge.Conditions" version="1.2.0.0" targetFramework="net45" />
-  <package id="Netco" version="1.5.5" targetFramework="net45" />
+  <package id="Netco" version="1.5.8" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net45" />
   <package id="ServiceStack.Text" version="4.0.60" targetFramework="net45" />
 </packages>

--- a/src/BigCommerceAccessTests/BigCommerceAccessTests.csproj
+++ b/src/BigCommerceAccessTests/BigCommerceAccessTests.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -48,9 +48,8 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\LinqToCsv.1.5.0.0\lib\net35\LINQtoCSV.dll</HintPath>
     </Reference>
-    <Reference Include="Netco, Version=1.5.5.0, Culture=neutral, PublicKeyToken=9d732c15ac2ec2c9, processorArchitecture=MSIL">
-      <HintPath>..\packages\Netco.1.5.5\lib\net45\Netco.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="Netco, Version=1.5.8.0, Culture=neutral, PublicKeyToken=9d732c15ac2ec2c9, processorArchitecture=MSIL">
+      <HintPath>..\packages\Netco.1.5.8\lib\net45\Netco.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=2.6.4.14350, Culture=neutral, PublicKeyToken=96d09a1eb7f44a77, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>

--- a/src/BigCommerceAccessTests/Orders/OrderTests.cs
+++ b/src/BigCommerceAccessTests/Orders/OrderTests.cs
@@ -23,7 +23,7 @@ namespace BigCommerceAccessTests.Orders
 		[ SetUp ]
 		public void Init()
 		{
-			NetcoLogger.LoggerFactory = new ConsoleLoggerFactory();
+			NetcoLogger.LoggerFactory = new NullLoggerFactory();
 			const string credentialsFilePath = @"..\..\Files\BigCommerceCredentials.csv";
 
 			var cc = new CsvContext();

--- a/src/BigCommerceAccessTests/Products/ProductsTests.cs
+++ b/src/BigCommerceAccessTests/Products/ProductsTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using BigCommerceAccess;
+using BigCommerceAccess.Misc;
 using BigCommerceAccess.Models.Configuration;
 using BigCommerceAccess.Models.Product;
 using FluentAssertions;
@@ -26,7 +27,7 @@ namespace BigCommerceAccessTests.Products
 		[ SetUp ]
 		public void Init()
 		{
-			NetcoLogger.LoggerFactory = new ConsoleLoggerFactory();
+			NetcoLogger.LoggerFactory = new NullLoggerFactory();
 			const string credentialsFilePath = @"..\..\Files\BigCommerceCredentials.csv";
 
 			var cc = new CsvContext();

--- a/src/BigCommerceAccessTests/packages.config
+++ b/src/BigCommerceAccessTests/packages.config
@@ -4,6 +4,6 @@
   <package id="CuttingEdge.Conditions" version="1.2.0.0" targetFramework="net45" />
   <package id="FluentAssertions" version="4.18.0" targetFramework="net45" />
   <package id="LinqToCsv" version="1.5.0.0" targetFramework="net45" />
-  <package id="Netco" version="1.5.5" targetFramework="net45" />
+  <package id="Netco" version="1.5.8" targetFramework="net45" />
   <package id="NUnit" version="2.6.4" targetFramework="net45" />
 </packages>

--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -24,4 +24,4 @@ using System.Runtime.InteropServices;
 
 // Keep in track with CA API version
 
-[ assembly : AssemblyVersion( "1.1.7.0" ) ]
+[ assembly : AssemblyVersion( "1.1.8.0" ) ]

--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -24,4 +24,4 @@ using System.Runtime.InteropServices;
 
 // Keep in track with CA API version
 
-[ assembly : AssemblyVersion( "1.1.9.0" ) ]
+[ assembly : AssemblyVersion( "1.1.10.0" ) ]

--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -24,4 +24,4 @@ using System.Runtime.InteropServices;
 
 // Keep in track with CA API version
 
-[ assembly : AssemblyVersion( "1.1.11.0" ) ]
+[ assembly : AssemblyVersion( "1.1.12.0" ) ]

--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -24,4 +24,4 @@ using System.Runtime.InteropServices;
 
 // Keep in track with CA API version
 
-[ assembly : AssemblyVersion( "1.1.10.0" ) ]
+[ assembly : AssemblyVersion( "1.1.11.0" ) ]

--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -24,4 +24,4 @@ using System.Runtime.InteropServices;
 
 // Keep in track with CA API version
 
-[ assembly : AssemblyVersion( "1.1.8.0" ) ]
+[ assembly : AssemblyVersion( "1.1.9.0" ) ]


### PR DESCRIPTION
**Summary**

**GUARD-752:**
- log messages now are more structured, searching by separate log fields now is possible in Kibana;
- retry messages connected to session mark and requested url, also retry information placed to logs too;
- logs are grouped by category: information, warning, critical;

**GUARD-805:**
- added products page size decreasing in case of receiving "unable to read data from the transport connection" error.