### PR TITLE
2020-09-22 GUARD-833 Handle-Huge-Product-Pages

### DIFF
--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -24,4 +24,4 @@ using System.Runtime.InteropServices;
 
 // Keep in track with CA API version
 
-[ assembly : AssemblyVersion( "1.1.12.0" ) ]
+[ assembly : AssemblyVersion( "1.1.13.0" ) ]


### PR DESCRIPTION
**Summary**
Some customers have products with tons of variations (~600), so JSON response can have huge size, more than 10MB (usually over 100KB).
BigCommerce server immediately closes connection after passing over 4MB. Found out this when tried to read incoming data through buffers of certain size.
But BigCommerce server supports response compression and I used this feature to solve our issue.